### PR TITLE
profiles: Move selinux usage tags from amd64 to all targets

### DIFF
--- a/app-admin/setools/files/setools-configure-ac.patch
+++ b/app-admin/setools/files/setools-configure-ac.patch
@@ -1,0 +1,30 @@
+diff --git a/configure.ac b/configure.ac
+index 6b03a34..ea0bfc0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -430,13 +430,10 @@ selinux_save_CPPFLAGS="${CPPFLAGS}"
+ CFLAGS="${CFLAGS} -I${sepol_devel_incdir} -I${selinux_devel_incdir}"
+ CPPFLAGS="${CPPFLAGS} -I${sepol_devel_incdir} -I${selinux_devel_incdir}"
+ AC_CHECK_HEADER([sepol/sepol.h], , AC_MSG_ERROR([could not find sepol headers at $sepol_devel_incdir - make sure libsepol-devel is installed]))
+-AC_CHECK_LIB([sepol], [sepol_policydb_read], ,
+-             AC_MSG_ERROR([could not find libsepol at $sepol_devel_libdir]))
++LIBS="-lsepol $LIBS"
+ AC_CHECK_HEADER([selinux/selinux.h], , AC_MSG_ERROR([could not find selinux headers at $selinux_devel_incdir - make sure libselinux-devel is installed]))
+ AC_CHECK_HEADER([selinux/context.h], , AC_MSG_ERROR([could not find selinux headers at $selinux_devel_incdir - make sure libselinux-devel is installed]))
+-AC_CHECK_LIB([selinux], [selinux_policy_root], ,
+-AC_MSG_ERROR([could not find libselinux at $selinux_devel_libdir]),
+-             -lsepol)
++LIBS="-lselinux $LIBS"
+ SELINUX_LIB_FLAG="-L${sepol_devel_libdir} -L${selinux_devel_libdir}"
+ CFLAGS="${selinux_save_CFLAGS}"
+ CPPFLAGS="${selinux_save_CPPFLAGS}"
+@@ -448,8 +445,6 @@ AC_ARG_ENABLE(sepol-src,
+               sepol_srcdir="")
+ if test "x${sepol_srcdir}" = "x"; then
+    sepol_srcdir=${sepol_devel_libdir}
+-   AC_CHECK_FILE([${sepol_srcdir}/libsepol.a],,
+-      AC_MSG_ERROR([make sure libsepol-static is installed]))
+ else
+    AC_MSG_CHECKING([for compatible sepol source tree])
+    sepol_version=${sepol_srcdir}/VERSION
+

--- a/app-admin/setools/setools-3.3.8-r7.ebuild
+++ b/app-admin/setools/setools-3.3.8-r7.ebuild
@@ -53,6 +53,7 @@ pkg_setup() {
 
 src_prepare() {
 	epatch "${FILESDIR}/support-cross-build.patch"
+	epatch "${FILESDIR}/setools-configure-ac.patch"
 
 	EPATCH_MULTI_MSG="Applying various (Gentoo) setool fixes... " \
 	EPATCH_SUFFIX="patch" \
@@ -88,6 +89,7 @@ src_configure() {
 		--disable-selinux-check \
 		--disable-bwidget-check \
 		--with-sepol-devel=${ROOT}/usr \
+		--with-selinux-devel=${ROOT}/usr \
 		$(use_enable python swig-python) \
 		$(use_enable java swig-java) \
 		$(use_enable X swig-tcl) \

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -65,13 +65,14 @@ IUSE="selinux"
 
 RDEPEND=">=sys-apps/baselayout-3.0.0"
 
-# Optionally enable SELinux and pull in policy for containers
+# Optionally enable SELinux for dbus and systemd but install packages and pull in policy for containers
 RDEPEND="${RDEPEND}
 	sys-apps/dbus[selinux?]
 	sys-apps/systemd[selinux?]
-	selinux? (
-		sec-policy/selinux-virt
-	)"
+	sec-policy/selinux-virt
+	sec-policy/selinux-base
+	sec-policy/selinux-base-policy
+"
 
 # Only applicable or available on amd64
 RDEPEND="${RDEPEND}

--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -1,17 +1,3 @@
-# Enable SELinux for amd64 targets
-coreos-base/coreos	    selinux
-sys-apps/dbus               selinux
-sys-apps/systemd            selinux
-
-# Enable SELinux for coreutils
-sys-apps/coreutils	    selinux
-
-# Enable SELinux for runc
-app-emulation/runc          selinux
-
-# Enable SELinux for tar
-app-arch/tar                selinux
-
 # Only ship microcode currently distributed by Intel
 # See https://bugs.gentoo.org/654638#c11 by iucode-tool maintainer
 sys-firmware/intel-microcode vanilla

--- a/profiles/coreos/amd64/sdk/package.use
+++ b/profiles/coreos/amd64/sdk/package.use
@@ -1,5 +1,1 @@
-# Enable SELinux for amd64 targets
-app-arch/tar                selinux
-sys-apps/coreutils          selinux
-coreos-base/coreos          selinux
 

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -70,3 +70,12 @@ dev-util/checkbashisms
 
 =sys-libs/libsepol-2.4 **
 =sys-libs/libselinux-2.4 **
+=sys-libs/libsemanage-2.4-r2 **
+=sys-apps/policycoreutils-2.4-r2 **
+=app-admin/setools-3.3.8-r7 **
+=dev-libs/ustr-1.0.4-r8 ~arm64
+=sys-apps/checkpolicy-2.4-r2 **
+=sec-policy/selinux-base-2.20141203-r14 **
+=sec-policy/selinux-base-policy-2.20141203-r14 **
+=sec-policy/selinux-virt-2.20141203-r14 **
+=sec-policy/selinux-unconfined-2.20141203-r14 **

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -100,3 +100,11 @@ sys-apps/man-db -nls
 
 # Disable zstd to avoid adding it to prod images until something needs it
 sys-fs/btrfs-progs -zstd
+
+# Enable SELinux for all targets
+coreos-base/coreos          selinux
+sys-apps/dbus               selinux
+sys-apps/systemd            selinux
+sys-apps/coreutils          selinux
+app-emulation/runc          selinux
+app-arch/tar                selinux

--- a/sys-libs/libsemanage/libsemanage-2.4-r2.ebuild
+++ b/sys-libs/libsemanage/libsemanage-2.4-r2.ebuild
@@ -78,6 +78,7 @@ multilib_src_compile() {
 		AR="$(tc-getAR)" \
 		CC="$(tc-getCC)" \
 		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		PREFIX="${EPREFIX}" \
 		all
 
 	if multilib_is_native_abi && use python; then


### PR DESCRIPTION
Enables SELinux for arm64.

**Note:** Should be done for Edge as well.
Needs qemu-aarch64 on the Jenkins worker. 