### PR TITLE
profiles: add libselinux keywords to the base profile for edge

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -93,3 +93,6 @@ dev-util/checkbashisms
 =dev-lang/rust-1.44.1 ~amd64 ~arm64
 
 =sys-fs/cryptsetup-2.0.3 ~amd64
+
+=sys-libs/libsepol-2.4 **
+=sys-libs/libselinux-2.4 **


### PR DESCRIPTION
So far libselinux was not installed for arm64, because it was simply masked.
We need to enable keywords for both libselinux and libsepol, to correctly build arm64 images including SELinux libs and binaries.