### PR TITLE
profiles: enable gssapi for bind-tools in SDK

### DIFF
--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -31,3 +31,6 @@ x11-libs/pixman static-libs
 
 cross-x86_64-cros-linux-gnu/gdb python_single_target_python3_6 -python_single_target_python3_7
 cross-aarch64-cros-linux-gnu/gdb python_single_target_python3_6 -python_single_target_python3_7
+
+# Enable gssapi for SDK
+net-dns/bind-tools           gssapi


### PR DESCRIPTION
In the past we [enabled](https://github.com/flatcar-linux/coreos-overlay/commit/172d9311bacd) the USE flag `gssapi` only for amd64, not for arm64.
We did so to avoid build issues that only happened for arm64.

However, that change caused interesting side effects in the SDK, where bind-tools ended up being compiled without `gssapi`.
It means, tools like `nsupdate` in the SDK are not able to deal with certain commands like `realm`.
As a result, configure scripts in packages like `sys-auth/sssd` fail, because they cannot run commands like `echo realm | nsupdate`.

We should bring the `gssapi` USE flag back to the SDK, to avoid such issues in the future.

## How to use

```
emerge bind-tools
```

## Testing done

local build