### PR TITLE
coreos-base/coreos-(cloud)init: Point to flatcar-master

### DIFF
--- a/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -11,7 +11,7 @@ inherit cros-workon systemd toolchain-funcs udev coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="8911fe016d69f67bfc61f36f59ca083a604f7109" # flatcar-master
+	CROS_WORKON_COMMIT="cfcc44197d11f44441e5aa2c9db34bcd0bf16015" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="e56e0c1f2174598c03ffedb26a8530849beef664" # flatcar-master
+	CROS_WORKON_COMMIT="365cfc7b128dfe0244ec20b4a006964f29633754" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Pulls in
https://github.com/flatcar-linux/coreos-cloudinit/pull/10
https://github.com/flatcar-linux/init/pull/30
to restore the systemd-networkd 243 behavior with
KeepConfiguration=dhcp-on-stop to prevent the network from going down
before the SIGTERM is broadcasted to orphaned processes not part of a
systemd unit.

**Note:** Should be merged for all maintenance branches (for Stable this also pulls in https://github.com/flatcar-linux/init/pull/29 which is good to have the unmanaged interface not shown as _configuring_ in `networkctl`)

# How to use

See linked PRs

# Testing done

Ran kola tests on all platforms.