### PR TITLE
trousers: add patch to fix CVE issues

### DIFF
--- a/app-crypt/trousers/files/trousers-0.3.14-CVE-2020-24330_CVE-2020-24331_CVE-2020-24332.patch
+++ b/app-crypt/trousers/files/trousers-0.3.14-CVE-2020-24330_CVE-2020-24331_CVE-2020-24332.patch
@@ -1,0 +1,58 @@
+Index: trousers-0.3.14/src/tcs/ps/tcsps.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcs/ps/tcsps.c
++++ trousers-0.3.14/src/tcs/ps/tcsps.c
+@@ -72,7 +72,7 @@ get_file()
+ 	}
+ 
+ 	/* open and lock the file */
+-	system_ps_fd = open(tcsd_options.system_ps_file, O_CREAT|O_RDWR, 0600);
++	system_ps_fd = open(tcsd_options.system_ps_file, O_CREAT|O_RDWR|O_NOFOLLOW, 0600);
+ 	if (system_ps_fd < 0) {
+ 		LogError("system PS: open() of %s failed: %s",
+ 				tcsd_options.system_ps_file, strerror(errno));
+Index: trousers-0.3.14/src/tcsd/svrside.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcsd/svrside.c
++++ trousers-0.3.14/src/tcsd/svrside.c
+@@ -473,6 +473,7 @@ main(int argc, char **argv)
+ 		}
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
++	setgid(pwd->pw_gid);
+ 	setuid(pwd->pw_uid);
+ #endif
+ #endif
+Index: trousers-0.3.14/src/tcsd/tcsd_conf.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcsd/tcsd_conf.c
++++ trousers-0.3.14/src/tcsd/tcsd_conf.c
+@@ -743,7 +743,7 @@ conf_file_init(struct tcsd_config *conf)
+ #ifndef SOLARIS
+ 	struct group *grp;
+ 	struct passwd *pw;
+-	mode_t mode = (S_IRUSR|S_IWUSR);
++	mode_t mode = (S_IRUSR|S_IWUSR|S_IRGRP);
+ #endif /* SOLARIS */
+ 	TSS_RESULT result;
+ 
+@@ -798,15 +798,15 @@ conf_file_init(struct tcsd_config *conf)
+ 	}
+ 
+ 	/* make sure user/group TSS owns the conf file */
+-	if (pw->pw_uid != stat_buf.st_uid || grp->gr_gid != stat_buf.st_gid) {
++	if (stat_buf.st_uid != 0 || grp->gr_gid != stat_buf.st_gid) {
+ 		LogError("TCSD config file (%s) must be user/group %s/%s", tcsd_config_file,
+-				TSS_USER_NAME, TSS_GROUP_NAME);
++				"root", TSS_GROUP_NAME);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ 
+-	/* make sure only the tss user can manipulate the config file */
++	/* make sure only the tss user can read (but not manipulate) the config file */
+ 	if (((stat_buf.st_mode & 0777) ^ mode) != 0) {
+-		LogError("TCSD config file (%s) must be mode 0600", tcsd_config_file);
++		LogError("TCSD config file (%s) must be mode 0640", tcsd_config_file);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ #endif /* SOLARIS */

--- a/app-crypt/trousers/trousers-0.3.14-r2.ebuild
+++ b/app-crypt/trousers/trousers-0.3.14-r2.ebuild
@@ -36,6 +36,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-libressl.patch"
 	"${FILESDIR}/${P}-fno-common.patch"
 	"${FILESDIR}/${P}-Makefile.am-Mark-tddl.a-nodist.patch"
+	"${FILESDIR}/${P}-CVE-2020-24330_CVE-2020-24331_CVE-2020-24332.patch"
 )
 
 DOCS="AUTHORS ChangeLog NICETOHAVES README TODO"


### PR DESCRIPTION
Add a [seclists patch](https://seclists.org/oss-sec/2020/q2/att-135/tcsd_fixes.patch) to `app-crypt/trousers-0.3.14-r2`.

# How to use / testing done
```
emerge-amd64-usr trousers
```