### PR TITLE
.github: fix mantle URL for downloading cork

### DIFF
--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-CORK_VERSION=$(curl -s https://api.github.com/repos/flatcar-linux/mantle/releases/latest | jq -r .tag_name | sed -e 's/^v//')
-curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
-curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig
+CORK_VERSION=$(curl -sL https://api.github.com/repos/kinvolk/mantle/releases/latest | jq -r .tag_name | sed -e 's/^v//')
+curl -L -o cork https://github.com/kinvolk/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
+curl -L -o cork.sig https://github.com/kinvolk/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig
 curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
 gpg --import Flatcar_Image_Signing_Key.asc
 gpg --verify cork.sig cork


### PR DESCRIPTION
The repo `github.com/flatcar-linux/mantle` has been moved to `github.com/kinvolk/mantle`.
However, Github Actions still fetch cork binaries from the original URL, by running `curl` without `-L`.
So the request does not get redirected to the new URL.
As a result, `CORK_VERSION` becomes null.

Fix it by replacing `flatcar-linux` with `kinvolk`, as well as adding `-L` to the curl command, just in case.
