### PR TITLE
eclass: remove also other optimization flags with -Wl,-O*

### DIFF
--- a/eclass/coreos-go-utils.eclass
+++ b/eclass/coreos-go-utils.eclass
@@ -87,7 +87,14 @@ go_export() {
 	# Remove certain flags from $LDFLAGS to fix validation errors in
 	# Go >= 1.15.5 like:
 	#   go build runtime/cgo: invalid flag in go:cgo_ldflag: -Wl,-O1
-	filter-ldflags "-Wl,-O1"
+	#
+	# Note, we need to manually strip only the optimization element of
+	# comma-separated flags, e.g. from `-Wl,-O1,-s` to `-Wl,-s`.
+	# To support multiple characters that can follow `-O`, e.g. `-Ofast`,
+	# we should use regexp like `[[:alnum:]]*`.
+	# Work-around for https://github.com/golang/go/pull/42631.
+	export LDFLAGS="$(echo "$LDFLAGS" | sed 's/,-O[[:alnum:]]*//g')"
+	filter-ldflags "-Wl"
 
 	export CC=$(tc-getCC)
 	export CXX=$(tc-getCXX)


### PR DESCRIPTION
We need to filter not only `-Wl,-O1`, but also other flags like `-Wl,-O2`, `-Wl,-Og`, `-Wl,-Os`, etc.
Otherwise, SDK build would fail, for example, as its default `$LDFLAGS` includes `-Wl,-O2`.

We need to manually strip only the optimization element of comma-separated flags, e.g. from `-Wl,-O1,-s` to `-Wl,-s`.
To support multiple characters that can follow `-O`, e.g. `-Ofast`, we should use regexp like `[[:alnum:]]*`.

## How to use

```
sudo emerge dev-lang/go:1.15
sudo FORCE_STAGES="stage4" ./bootstrap_sdk
```

## Testing done

SDK build passed in CI.
