### PR TITLE
coreos-base/coreos-init: Update to latest repository state

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="365cfc7b128dfe0244ec20b4a006964f29633754" # flatcar-master
+	CROS_WORKON_COMMIT="5b0fdd5e2202b19e3b755aa88dc0f282ded5221e" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/31
to make extend-filesystems more robust against a race.



# How to use


# Testing done

Kola tests passed [here](http://localhost:9091/job/os/job/manifest/1478/cldsv)
