### PR TITLE
profiles: make SDK include dev-util/dwarves

### DIFF
--- a/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
+++ b/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
@@ -33,6 +33,7 @@ DEPEND="
 	dev-util/boost-build
 	dev-util/catalyst
 	dev-util/checkbashisms
+	dev-util/dwarves
 	dev-util/patchelf
 	dev-vcs/repo
 	net-dns/bind-tools

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -82,3 +82,6 @@ dev-util/checkbashisms
 =sys-fs/cryptsetup-2.0.3 ~amd64
 
 =sys-libs/libseccomp-2.5.0 ~amd64 ~arm64
+
+>=dev-util/dwarves-1.18 ~amd64
+>=dev-libs/elfutils-0.178 ~amd64

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -26,6 +26,7 @@ dev-python/uritemplate -python_targets_python3_6
 sys-apps/portage -python_targets_python3_6
 
 # python3 only
+dev-util/dwarves python_single_target_python3_6
 dev-util/gdbus-codegen python_single_target_python3_6
 dev-util/glib-utils python_single_target_python3_6
 net-fs/samba python_single_target_python3_6


### PR DESCRIPTION
To build Kernel with `CONFIG_DEBUG_INFO_BTF`, we need to make `pahole` in dwarves included in the Flatcar SDK.

To do that, we need to make it accept `~amd64` keywords for dwarves and binutils.
Also enable USE flag `python_single_target_python3_6` for dwarves.

See also https://github.com/kinvolk/Flatcar/issues/225 .

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/126.

## How to use

```
sudo emerge dev-util/dwarves
```

## Testing done

CI passed http://localhost:9091/job/os/job/manifest/1484/cldsv/
