### PR TITLE
Add the support for GPU on Azure

### DIFF
--- a/coreos-base/oem-azure-pro/files/base/README
+++ b/coreos-base/oem-azure-pro/files/base/README
@@ -1,0 +1,4 @@
+These Ignition configs are part of the OEM configuration. Do not modify
+them. If you want to write an Ignition config directly to disk, put it in
+../config.ign and it will be applied at first boot instead of a config
+in userdata.

--- a/coreos-base/oem-azure-pro/files/base/base.ign
+++ b/coreos-base/oem-azure-pro/files/base/base.ign
@@ -1,0 +1,37 @@
+{
+  "ignition": {
+    "version": "2.1.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "filesystem": "root",
+        "path": "/etc/systemd/system/waagent.service",
+        "contents": {
+          "source": "oem:///units/waagent.service"
+        },
+        "mode": 292
+      },
+      {
+        "filesystem": "root",
+        "path": "/etc/systemd/system/nvidia.service",
+        "contents": {
+          "source": "oem:///units/nvidia.service"
+        },
+        "mode": 292
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "name": "waagent.service",
+        "enabled": true
+      },
+      {
+        "name": "nvidia.service",
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/coreos-base/oem-azure-pro/files/base/default.ign
+++ b/coreos-base/oem-azure-pro/files/base/default.ign
@@ -1,0 +1,14 @@
+{
+  "ignition": {
+    "version": "2.1.0"
+  },
+  "systemd": {
+    "units": [
+      {
+        "name": "oem-cloudinit.service",
+        "enabled": true,
+        "contents": "[Unit]\nDescription=Cloudinit from Azure metadata\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/coreos-cloudinit --oem=azure\n\n[Install]\nWantedBy=multi-user.target\n"
+      }
+    ]
+  }
+}

--- a/coreos-base/oem-azure-pro/files/grub.cfg
+++ b/coreos-base/oem-azure-pro/files/grub.cfg
@@ -1,0 +1,9 @@
+# Flatcar GRUB settings
+
+set oem_id="azure"
+
+# Azure only has a serial console.
+set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200 flatcar.autologin"
+serial com0 --speed=115200 --word=8 --parity=no
+terminal_input serial_com0
+terminal_output serial_com0

--- a/coreos-base/oem-azure-pro/files/oem-release
+++ b/coreos-base/oem-azure-pro/files/oem-release
@@ -1,0 +1,5 @@
+ID=azure
+VERSION_ID=@@OEM_VERSION_ID@@
+NAME="Microsoft Azure"
+HOME_URL="https://azure.microsoft.com/"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-azure-pro/files/units/waagent.service
+++ b/coreos-base/oem-azure-pro/files/units/waagent.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Microsoft Azure Agent
+Wants=network-online.target sshd-keygen.service
+After=network-online.target sshd-keygen.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5s
+ExecStart=/usr/share/oem/python/bin/python -u /usr/share/oem/bin/waagent -daemon
+
+[Install]
+WantedBy=multi-user.target

--- a/coreos-base/oem-azure-pro/metadata.xml
+++ b/coreos-base/oem-azure-pro/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-azure-pro/oem-azure-pro-2.2.46.ebuild
+++ b/coreos-base/oem-azure-pro/oem-azure-pro-2.2.46.ebuild
@@ -1,0 +1,37 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for Azure"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+# This source is a superset of oem-azure and implments the pro bits. The source
+# of oem-azure-pro is duplicated from oem-azure because making using of RDEPEND
+# would result in the conflict of `base.ign`
+RDEPEND="
+  ~app-emulation/wa-linux-agent-${PV}
+  x11-drivers/nvidia-drivers
+"
+
+src_prepare() {
+	sed -e "s\\@@OEM_VERSION_ID@@\\${PVR}\\g" \
+		"${FILESDIR}/oem-release" > "${T}/oem-release" || die
+}
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins "${FILESDIR}/grub.cfg"
+	doins "${T}/oem-release"
+	doins -r "${FILESDIR}/base"
+	doins -r "${FILESDIR}/units"
+}

--- a/coreos-devel/board-packages/board-packages-0.0.1.ebuild
+++ b/coreos-devel/board-packages/board-packages-0.0.1.ebuild
@@ -26,6 +26,7 @@ RDEPEND="
 		coreos-base/nova-agent-container
 		coreos-base/nova-agent-watcher
 		dev-lang/python-oem
+		x11-drivers/nvidia-drivers
 	)
 	arm64? (
 		sys-boot/grub

--- a/x11-drivers/nvidia-drivers/files/bin/install-nvidia
+++ b/x11-drivers/nvidia-drivers/files/bin/install-nvidia
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. /usr/share/coreos/release
+NVIDIA_DRIVER_BASENAME="$1"
+
+emerge-gitclone
+emerge -gKv coreos-sources > /dev/null
+cp "/usr/lib64/modules/$(ls /usr/lib64/modules)/build/.config" /usr/src/linux/
+make -C /usr/src/linux modules_prepare
+
+cd "/nvidia/${NVIDIA_DRIVER_BASENAME}"
+./nvidia-installer -s -n \
+  --no-check-for-alternate-installs \
+  --no-kernel-module-source \
+  --no-opengl-files \
+  --no-distro-scripts \
+  --kernel-install-path="${PWD}" \
+  --log-file-name="${PWD}/nvidia-installer.log" || true

--- a/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -euo pipefail
+. /usr/share/flatcar/release
+. /usr/share/flatcar/update.conf
+
+NVIDIA_DRIVER_VERSION=450.80.02
+NVIDIA_PRODUCT_TYPE=tesla
+NVIDIA_DOWNLOAD_BASEURL="https://us.download.nvidia.com/${NVIDIA_PRODUCT_TYPE}/"
+NVIDIA_DRIVER_BASENAME="NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}"
+NVIDIA_WORKDIR='nvidia-workdir'
+
+FLATCAR_DEVELOPER_CONTAINER="flatcar_developer_container.bin"
+FLATCAR_DEVELOPER_CONTAINER_URL=""
+FLATCAR_ROOT_WORKDIR="/opt/nvidia/workdir"
+FLATCAR_KERNEL_VERSION=$(uname -r)
+NVIDIA_FLATCAR_VERSION_PAIR="${NVIDIA_DRIVER_VERSION}/${FLATCAR_KERNEL_VERSION}"
+NVIDIA_CURRENT_INSTALLATION="current"
+
+function download_flatcar_developer_container() {
+  echo Downloading Flatcar Container Linux Developer Container for version: "${FLATCAR_RELEASE_VERSION}"
+
+  if [[ ! -f "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}" ]]
+  then
+
+    if [[ "$GROUP" == "developer" ]]
+    then
+      FLATCAR_DEVELOPER_CONTAINER_URL="https://storage.googleapis.com/flatcar-jenkins/developer/developer/boards/${FLATCAR_RELEASE_BOARD}/${FLATCAR_RELEASE_VERSION}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
+    else
+      FLATCAR_DEVELOPER_CONTAINER_URL="https://${GROUP}.release.flatcar-linux.net/${FLATCAR_RELEASE_BOARD}/${FLATCAR_RELEASE_VERSION}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
+    fi
+
+    if [ ! -n "${FLATCAR_DEVELOPER_CONTAINER_URL}" ]
+    then
+      return 1
+    fi
+
+    curl -L "${FLATCAR_DEVELOPER_CONTAINER_URL}" -o "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
+    bzip2 -d "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
+
+  fi
+
+  return 0
+}
+
+function download_nvidia_driver_archive() {
+  echo Downloading NVIDIA "${NVIDIA_DRIVER_VERSION}" Driver
+
+  if [ ! -f "${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}/${NVIDIA_DRIVER_BASENAME}.run" ]
+  then
+    curl --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 "${NVIDIA_DOWNLOAD_BASEURL}/${NVIDIA_DRIVER_VERSION}/${NVIDIA_DRIVER_BASENAME}.run" -o "${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}/${NVIDIA_DRIVER_BASENAME}.run.tmp"
+    mv "${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}/${NVIDIA_DRIVER_BASENAME}.run.tmp" "${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}/${NVIDIA_DRIVER_BASENAME}.run"
+  fi
+}
+
+function extract_nvidia_installer() {
+  echo Extract the NVIDIA Driver Installer ${NVIDIA_DRIVER_VERSION}
+
+  pushd "${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}"
+  chmod +x "${NVIDIA_DRIVER_BASENAME}.run"
+  "./${NVIDIA_DRIVER_BASENAME}.run" -x -s
+  popd
+}
+
+function run_nspawn_container() {
+  echo Spawn system-nspawn container to install the NVIDIA drivers
+
+  sudo systemd-nspawn --image="${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}" --bind="${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}":/nvidia --bind=/usr/share/oem/bin:/app/bin/ /app/bin/install-nvidia "$NVIDIA_DRIVER_BASENAME"
+}
+
+function copy_nvidia_build_artifacts() {
+  mkdir -p "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/lib64"
+  cp "$FLATCAR_ROOT_WORKDIR/$NVIDIA_WORKDIR/${NVIDIA_DRIVER_BASENAME}"/*.so.* "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/lib64/"
+
+  mkdir -p /opt/bin
+  cp "$FLATCAR_ROOT_WORKDIR/$NVIDIA_WORKDIR/${NVIDIA_DRIVER_BASENAME}"/{nvidia-debugdump,nvidia-cuda-mps-control,nvidia-xconfig,nvidia-modprobe,nvidia-smi,nvidia-cuda-mps-server,nvidia-persistenced,nvidia-settings} /opt/bin/
+
+  mkdir -p "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/lib64/modules/$(uname -r)/video/"
+  cp "$FLATCAR_ROOT_WORKDIR/$NVIDIA_WORKDIR/${NVIDIA_DRIVER_BASENAME}"/kernel/*.ko "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/lib64/modules/$(uname -r)/video/"
+
+  pushd /opt/nvidia
+  ln -sfn "${NVIDIA_FLATCAR_VERSION_PAIR}" current
+  popd
+}
+
+function install_and_load() {
+  insmod "/opt/nvidia/${NVIDIA_CURRENT_INSTALLATION}/lib64/modules/$(uname -r)/video/nvidia.ko"
+
+  if [ ! -f /dev/nvidiactl ]
+  then
+    mknod -m 666 /dev/nvidiactl c 195 255
+  fi
+
+  if [ ! -f /dev/nvidia0 ]
+  then
+    mknod -m 666 /dev/nvidia0 c 195 0
+  fi
+
+  mkdir -p /etc/ld.so.conf.d/
+  echo "/opt/nvidia/${NVIDIA_CURRENT_INSTALLATION}/lib64" > /etc/ld.so.conf.d/nvidia.conf
+  ldconfig
+}
+
+function verify_installation() {
+  nvidia-smi
+  nvidia-modprobe -u -m -c 0
+}
+
+function is_nvidia_installation_required() {
+  if [[ -z "$(lspci | grep -i "${NVIDIA_PRODUCT_TYPE}")" ]]; then
+    return 1
+  fi
+
+  if [[ ! -d "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}" ]]; then
+    return 1
+  fi
+}
+
+function presetup() {
+  mkdir -p "${FLATCAR_ROOT_WORKDIR}"
+  mkdir -p "${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}"
+}
+
+function setup() {
+  download_flatcar_developer_container
+  download_nvidia_driver_archive
+  extract_nvidia_installer
+  run_nspawn_container
+  copy_nvidia_build_artifacts
+  install_and_load
+  verify_installation
+}
+
+if ! is_nvidia_installation_required
+then
+  presetup "$@"
+  setup "$@"
+  exit 0
+fi

--- a/x11-drivers/nvidia-drivers/files/units/nvidia.service
+++ b/x11-drivers/nvidia-drivers/files/units/nvidia.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NVIDIA Configure Service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+Restart=no
+Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+ExecStart=/usr/share/oem/bin/setup-nvidia
+
+[Install]
+WantedBy=multi-user.target

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-450.80.02.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-450.80.02.ebuild
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Kinvolk GmbH. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="NVIDIA drivers"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+RDEPEND=""
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins -r "${FILESDIR}/units"
+	exeinto "/usr/share/oem/bin"
+	doexe "${FILESDIR}/bin/install-nvidia"
+	doexe "${FILESDIR}/bin/setup-nvidia"
+}


### PR DESCRIPTION
# Add the support for GPU on Azure - Flatcar Pro

This adds the support of GPU on Azure. This adds a new OEM `oem-azure-pro` which is essentially a superset of the `oem-azure`. The implementation is duplicated but later can be refactored to remove the duplication. This also adds the `nvidia-driver` ebuilds to install the NVIDIA during the boot process. 

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>


# How to use

```
./build_packages
./build_image
./image_to_vm --format=azure_pro
```
Boot and check the output of the command of `nvidia-smi`

# Testing done

Few bits are added are not tested. Also, The tests are done on the stable rebase, and not on the main. This PR needs to be picked to beta. 

To be merged with kinvolk/flatcar-scripts#103

Jenkins build http://localhost:9091/job/os/job/board/job/packages-matrix/2038/cldsv/ 
image-matrix rebuild http://localhost:9091/job/os/job/board/job/image-matrix/1627/
