### PR TITLE
.github: use create-pull-request@v3 to fix set-env issues

### DIFF
--- a/.github/workflows/containerd-releases-main.yml
+++ b/.github/workflows/containerd-releases-main.yml
@@ -33,7 +33,7 @@ jobs:
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
         run: .github/workflows/containerd-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-releases-main.yml
+++ b/.github/workflows/docker-releases-main.yml
@@ -33,7 +33,7 @@ jobs:
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
         run: .github/workflows/docker-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -32,7 +32,7 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
         run: .github/workflows/go-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -34,7 +34,7 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -34,7 +34,7 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kernel-releases-main.yml
+++ b/.github/workflows/kernel-releases-main.yml
@@ -32,7 +32,7 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -34,7 +34,7 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runc-releases-main.yml
+++ b/.github/workflows/runc-releases-main.yml
@@ -37,7 +37,7 @@ jobs:
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -31,7 +31,7 @@ jobs:
         run: .github/workflows/rust-apply-patch.sh
       - name: Create pull request for main
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github Actions for Rust started failing with following errors:

```
Error: Unable to process command '::set-env name=PULL_REQUEST_NUMBER::718' successfully.
Error: The `set-env` command is disabled. Please upgrade to using
Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.
For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

It happens because we have used `peter-evans/create-pull-request@v2`, which did not have a bug fix for the set-env issue.
The bug was fixed in create-pull-request [v3.4.1](https://github.com/peter-evans/create-pull-request/releases/tag/v3.4.1).
So we just need to update the version to `v3`, which already includes v3.4.1.
