### PR TITLE
profiles: disable jpeg for qemu

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -15,7 +15,7 @@ dev-vcs/git		webdav curl bash-completion
 net-misc/curl		kerberos threads
 net-misc/iputils	arping tracepath traceroute
 sys-devel/gettext	-git
-app-emulation/qemu	aio caps curl jpeg ncurses png python threads uuid vhost-net virtfs vnc -xkb qemu_softmmu_targets_x86_64 qemu_softmmu_targets_aarch64
+app-emulation/qemu	aio caps curl ncurses png python threads uuid vhost-net virtfs vnc -xkb qemu_softmmu_targets_x86_64 qemu_softmmu_targets_aarch64
 
 # python3 problems
 app-portage/gentoolkit -python_targets_python3_6

--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -12,7 +12,7 @@ app-crypt/gnupg smartcard usb
 
 # for qemu
 app-arch/bzip2 static-libs
-app-emulation/qemu static-user
+app-emulation/qemu static-user -jpeg
 dev-libs/glib static-libs
 dev-libs/libaio static-libs
 dev-libs/libpcre static-libs


### PR DESCRIPTION
Qemu has enabled `jpeg` USE flag since the beginning, without any reason specified.
As a result, qemu pulls in unnecessary packages, `virtual/jpeg` as well as `media-libs/libjpeg-turbo`.
However, Flatcar runs qemu always with `-display none` option.
So the `jpeg` flag is not needed at all.

Simply remove `jpeg` USE flag from qemu.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/133.

## How to use

```
sudo FORCE_STAGES="stage4" bootstrap_sdk
```

## Testing done

SDK build passed. http://localhost:9091/job/os/job/manifest/1594/cldsv/