### PR TITLE
Update systemd-9999.ebuild to use systemd-resolved's stub resolver

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -196,16 +196,6 @@ src_prepare() {
 	# Flatcar: We carry our own patches, we don't use the ones
 	# from Gentoo. Thus we dropped the `if ! use vanilla` code
 	# here.
-	#
-	# Flatcar: Use the resolv.conf managed by systemd-resolved.
-	# This shouldn't be necessary anymore. Added because of a bug
-	# https://github.com/systemd/systemd/issues/3826, which is
-	# apparently resolved in
-	# https://github.com/systemd/systemd/pull/5276 but another reason is
-	# that when /etc/resolve.conf is bind-mounted to a new network
-	# namespace it shouldn't contain the loopback IP address of the host
-	# which is not reachable from another network namespace.
-	sed -i -e 's,/run/systemd/resolve/stub-resolv.conf,/run/systemd/resolve/resolv.conf,' tmpfiles.d/etc.conf.m4 || die
 
 	default
 }


### PR DESCRIPTION
# Re-Enable the stub-resolver to fully utilize systemd-resolved...
...for applications that do not do nsswitch (https://github.com/kinvolk/baselayout/pull/10)

REQUIRES https://github.com/kinvolk/baselayout/pull/11

Goes in tandem with https://github.com/kinvolk/baselayout/pull/10

# How to use

Set up Split-Horizon DNS as outlined in https://github.com/kinvolk/baselayout/pull/10 

# Testing done

Same tests as https://github.com/kinvolk/baselayout/pull/10 but with `dig` instead of ping to bypass nsswitch

Related: https://github.com/kinvolk/Flatcar/issues/285
