### PR TITLE
.github: add Github Actions for auto-updating linux-firmware

### DIFF
--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+UPDATE_NEEDED=1
+
+. .github/workflows/common.sh
+
+if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
+
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+
+# Parse the Manifest file for already present source files and keep the latest version in the current series
+VERSION_OLD=$(sed -n "s/^DIST linux-firmware-\([0-9]*\).*$/\1/p" sys-kernel/coreos-firmware/Manifest | sort -ruV | head -n1)
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Linux Firmware, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
+
+git mv $(ls -1 sys-kernel/coreos-firmware/coreos-firmware-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "sys-kernel/coreos-firmware/coreos-firmware-${VERSION_NEW}.ebuild"
+
+popd >/dev/null || exit
+
+generate_patches sys-kernel coreos-firmware "Linux Firmware"
+
+apply_patches
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
+echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"

--- a/.github/workflows/firmware-releases-main.yml
+++ b/.github/workflows/firmware-releases-main.yml
@@ -1,0 +1,44 @@
+name: Get the latest Linux Firmware release for main
+on:
+  schedule:
+    - cron:  '0 7 * * 4'
+
+jobs:
+  get-firmware-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Linux Firmware release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+          versionMain=$(git -C linux-firmware ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
+          rm -rf linux-firmware
+          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
+          echo ::set-output name=BASE_BRANCH_MAIN::main
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for main
+        id: apply-patch-main
+        env:
+          TARGET: main
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+        run: .github/workflows/firmware-apply-patch.sh
+      - name: Create pull request for main
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          branch: firmware-${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}-main
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Linux Firmware in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          commit-message: Upgrade Linux Firmware in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          body: Upgrade Linux Firmware in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          labels: main


### PR DESCRIPTION
Add Github Actions for coreos-firmware, just like other Kernel packages, basically to detect new releases from the upstream [linux-firmware](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git) repo.

Fixes https://github.com/kinvolk/Flatcar/issues/289.