### PR TITLE
app-emulation/containerd: Enable the CRI plugin

### DIFF
--- a/app-emulation/containerd/files/config.toml
+++ b/app-emulation/containerd/files/config.toml
@@ -6,8 +6,7 @@ state = "/run/docker/libcontainerd/containerd"
 subreaper = true
 # set containerd's OOM score
 oom_score = -999
-# CRI plugin listens on a TCP port by default
-disabled_plugins = ["cri"]
+disabled_plugins = []
 
 # grpc configuration
 [grpc]


### PR DESCRIPTION
Kubernetes uses containerd through the cri plugin which currently is
disabled due to it listening on a TCP port. Now the plugin is not
listening on a TCP port anymore but uses the same socket as gRPC.
We have documented how to enable it in
https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-from-docker-to-containerd-for-kubernetes/
but it should work by default.

Fixes https://github.com/kinvolk/Flatcar/issues/283

Note: Picked for Stable and Beta

# How to use

The kubelet still needs to know the special socket location but otherwise no customizations should be needed to us containerd.

```
--container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock
``` 

# Testing done

The change is the same as in https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-from-docker-to-containerd-for-kubernetes/ and was tested at that time.