### PR TITLE
app-emulation/containerd: Explicitly disable TCP

### DIFF
--- a/app-emulation/containerd/files/config.toml
+++ b/app-emulation/containerd/files/config.toml
@@ -8,6 +8,9 @@ subreaper = true
 oom_score = -999
 disabled_plugins = []
 
+[plugins.cri]
+disable_tcp_service = true
+
 # grpc configuration
 [grpc]
 address = "/run/docker/libcontainerd/docker-containerd.sock"


### PR DESCRIPTION
Even though the containerd cri plugin should not listen on TCP by
default it still seems to do so.
Explicitly disable it to make sure it won't be on.

# How to use

Run the kola tests

# Testing done

[Ongoing](http://localhost:9091/job/os/job/manifest/1634/cldsv/)