### PR TITLE
sys-apps/baselayout: Point to latest repo state

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="b989f2c9619919495a1e9c0e40f3134a7fe0394c" # flatcar-master
+	CROS_WORKON_COMMIT="69ed7c7a3fd7e2f8ffd5869130ba1cf7d7750f6d" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/baselayout/pull/13
to set sysctl rp_filter=0 and reorder how the configs are applied.

Note: Should be applied for 2705 and 2605 but applying may need a new baselayout branch because the changes for the PAM update are also part of it but not in 2605 and 2705

# How to use

# Testing done

See https://github.com/kinvolk/baselayout/pull/13
