### PR TITLE
sys-apps/baselayout: Point to flatcar-2605-2705 branch

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="caa00726cc26b75ff6056df56d497a036c52a91e" # flatcar-master
+	CROS_WORKON_COMMIT="9cafb4b458c081cbcab2e660a147e6d9039ff492" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/baselayout/pull/13
to set sysctl rp_filter=0 and reorder how the configs are applied.
A branch flatcar-2605-2705 is used as maintenance branch.

Note: Should be picked for 2605 and 2705