### PR TITLE
sys-apps/baselayout: Point to latest repo state

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="69ed7c7a3fd7e2f8ffd5869130ba1cf7d7750f6d" # flatcar-master
+	CROS_WORKON_COMMIT="abbf6b604659f780846a881a6c6bafbcd8e2da87" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/baselayout/pull/10
https://github.com/kinvolk/baselayout/pull/14
https://github.com/kinvolk/baselayout/pull/11
to configure systemd-resolved.

# How to use


# Testing done

