### PR TITLE
app-emulation/containerd: Disable shim debug logs

### DIFF
--- a/app-emulation/containerd/files/config.toml
+++ b/app-emulation/containerd/files/config.toml
@@ -24,5 +24,3 @@ runtime = "runc"
 # do not use a shim when starting containers, saves on memory but
 # live restore is not supported
 no_shim = false
-# display shim logs in the containerd daemon's log output
-shim_debug = true


### PR DESCRIPTION
Debug output clutters the logs which with K8s liveness/readiness probes
quickly becomes a problem.

Fixes https://github.com/kinvolk/Flatcar/issues/313


# How to use

Run a cluster with liveness/readiness probes and see that the log output is reduced because it does not contain `level=debug` entries anymore.

# Testing done

None
