### PR TITLE
coreos-base/afterburn: Restart on failure and keep unit active

### DIFF
--- a/coreos-base/afterburn/files/coreos-metadata-sshkeys@.service
+++ b/coreos-base/afterburn/files/coreos-metadata-sshkeys@.service
@@ -3,6 +3,9 @@ Description=Flatcar Metadata Agent (SSH Keys)
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=10
 Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --ssh-keys=%i
 

--- a/coreos-base/afterburn/files/coreos-metadata.service
+++ b/coreos-base/afterburn/files/coreos-metadata.service
@@ -3,6 +3,9 @@ Description=Flatcar Metadata Agent
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=10
 Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
 ExecStartPost=ln -fs /run/metadata/flatcar /run/metadata/coreos


### PR DESCRIPTION
When the metadata server is unavailable for some time the service did
not retry. Also, the service was triggered possibly multiple times
each time another service pulled it in which can cause problems if,
e.g., the service experiences a failure and corrupts the existing file
which could have been kept because rerunning wasn't needed.

Fixes https://github.com/kinvolk/Flatcar/issues/311

# How to use

Build and verify that all tests pass

# Testing done

None
