### PR TITLE
sys-apps/systemd: Switch back to using a merged /etc/resolv.conf

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -194,6 +194,14 @@ src_prepare() {
 	# from Gentoo. Thus we dropped the `if ! use vanilla` code
 	# here.
 
+	# Flatcar: The Kubelet takes /etc/resolv.conf for, e.g., CoreDNS which has dnsPolicy "default", but unless
+	# the kubelet --resolv-conf flag is set to point to /run/systemd/resolve/resolv.conf this won't work with
+	# /etc/resolv.conf pointing to /run/systemd/resolve/stub-resolv.conf which configures 127.0.0.53.
+	# See https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues
+	# This means that users who need split DNS to work should point /etc/resolv.conf back to /run/systemd/resolve/stub-resolv.conf
+	# (and if using K8s configure the kubelet resolvConf variable/--resolv-conf flag to /run/systemd/resolve/resolv.conf).
+	sed -i -e 's,/run/systemd/resolve/stub-resolv.conf,/run/systemd/resolve/resolv.conf,' tmpfiles.d/etc.conf.m4 || die
+
 	default
 }
 


### PR DESCRIPTION
Using only 127.0.0.53 for /etc/resolv.conf causes problems for
Kubernetes which is not systemd-resolved aware yet (the kubelet passes
on /etc/resolv.conf contents to containers).
Switch back for now to merging all DNS servers into /etc/resolv.conf
which breaks split DNS and we need to document how to make split DNS
work for those that want it.

(Reverts the change of https://github.com/flatcar-linux/coreos-overlay/pull/730)

# How to use

Needs a docs PR and a kubelet upstream issue would also be nice


# Testing done


