### PR TITLE
app-emulation/containerd: Switch to default socket location

### DIFF
--- a/app-emulation/containerd/files/config.toml
+++ b/app-emulation/containerd/files/config.toml
@@ -1,7 +1,7 @@
 # persistent data location
 root = "/var/lib/containerd"
 # runtime state information
-state = "/run/docker/libcontainerd/containerd"
+state = "/run/containerd"
 # set containerd as a subreaper on linux when it is not running as PID 1
 subreaper = true
 # set containerd's OOM score
@@ -10,7 +10,7 @@ disabled_plugins = []
 
 # grpc configuration
 [grpc]
-address = "/run/docker/libcontainerd/docker-containerd.sock"
+address = "/run/containerd/containerd.sock"
 # socket uid
 uid = 0
 # socket gid

--- a/app-emulation/containerd/files/containerd-1.0.0.service
+++ b/app-emulation/containerd/files/containerd-1.0.0.service
@@ -8,9 +8,12 @@ Delegate=yes
 Environment=CONTAINERD_CONFIG=/usr/share/containerd/config.toml
 ExecStartPre=mkdir -p /run/docker/libcontainerd
 ExecStartPre=ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd --config ${TORCX_UNPACKDIR}${TORCX_IMAGEDIR}${CONTAINERD_CONFIG}
 KillMode=process
+Type=notify
 Restart=always
+RestartSec=5
 
 # (lack of) limits from the upstream docker service unit
 LimitNOFILE=1048576

--- a/app-emulation/containerd/files/containerd-1.0.0.service
+++ b/app-emulation/containerd/files/containerd-1.0.0.service
@@ -6,6 +6,8 @@ After=network.target
 [Service]
 Delegate=yes
 Environment=CONTAINERD_CONFIG=/usr/share/containerd/config.toml
+ExecStartPre=mkdir -p /run/docker/libcontainerd
+ExecStartPre=ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
 ExecStart=/usr/bin/containerd --config ${TORCX_UNPACKDIR}${TORCX_IMAGEDIR}${CONTAINERD_CONFIG}
 KillMode=process
 Restart=always


### PR DESCRIPTION
The upstream socket is under /run/containerd/containerd.sock which many
tools like crictl will use by default and diverging causes users to
always have to configure a non-default location.
Switch to the upstream default while still keeping a symlink so that
users are not forced to update their configurations they had to do for
the non-default location. This also keeps Docker using the old socket
location as an assertion that the symlink works. The state directory
is also switch to the default location.

# How to use

Build an image and run the tests

# Testing done

Manually created a drop-in config with the new contents.