### PR TITLE
.github: fix env vars and sed expressions

### DIFF
--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -13,14 +13,14 @@ fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-VERSION_OLD=$(sed -n "s/^DIST containerd-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/containerd/Manifest | sort -ruV | head -n1)
+VERSION_OLD=$(sed -n "s/^DIST containerd-\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p" app-emulation/containerd/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   echo "already the latest Containerd, nothing to do"
   UPDATE_NEEDED=0
   exit 0
 fi
 
-DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
+DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
 
 # we need to update not only the main ebuild file, but also its CONTAINERD_COMMIT,
 # which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream containerd.

--- a/.github/workflows/containerd-releases-main.yml
+++ b/.github/workflows/containerd-releases-main.yml
@@ -14,7 +14,7 @@ jobs:
         id: fetch-latest-release
         run: |
           git clone https://github.com/containerd/containerd
-          versionMain=$(git -C containerd ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
+          versionMain=$(git -C containerd ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*\.[0-9]*\.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
           commitMain=$(git -C containerd rev-parse v${versionMain})
           rm -rf containerd
           echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})

--- a/.github/workflows/docker-releases-main.yml
+++ b/.github/workflows/docker-releases-main.yml
@@ -14,7 +14,7 @@ jobs:
         id: fetch-latest-release
         run: |
           git clone https://github.com/docker/docker-ce docker
-          versionMain=$(git -C docker ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
+          versionMain=$(git -C docker ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*\.[0-9]*\.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
           commitMain=$(git -C docker rev-parse --short=7 v${versionMain})
           rm -rf docker
           echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -16,7 +16,7 @@ jobs:
           GO_VERSION: "1.15"
         run: |
           git clone --depth=1 --no-checkout https://github.com/golang/go
-          versionMain=$(git -C go ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/go${GO_VERSION}.[0-9]*$/s/^refs\/tags\/go//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -1)
+          versionMain=$(git -C go ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/go${GO_VERSION}\.[0-9]*$/s/^refs\/tags\/go//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -1)
           rm -rf go
           echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
           echo ::set-output name=BASE_BRANCH_MAIN::main

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch latest Go release
         id: fetch-latest-release
         env:
-          GO_VERSION: 1.15
+          GO_VERSION: "1.15"
         run: |
           git clone --depth=1 --no-checkout https://github.com/golang/go
           versionMain=$(git -C go ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/go${GO_VERSION}.[0-9]*$/s/^refs\/tags\/go//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -1)

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -15,7 +15,7 @@ fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-VERSION_OLD=$(sed -n "s/^DIST patch-\(${VERSION_SHORT}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
+VERSION_OLD=$(sed -n "s/^DIST patch-\(${VERSION_SHORT}\.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
 if [[ -z "${VERSION_OLD}" ]]; then
   VERSION_OLD=$(sed -n "s/^DIST linux-\(${VERSION_SHORT}*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
 fi

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           KV_MAIN=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image_packages.txt" | grep -o 'coreos-kernel.*' | cut -d '-' -f 3- | cut -d . -f 1-2)
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
-          versionMaintenance=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
+          versionMaintenance=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}\.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
           rm -rf linux
           maintenanceBranch=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
           echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           KV_MAIN=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image_packages.txt" | grep -o 'coreos-kernel.*' | cut -d '-' -f 3- | cut -d . -f 1-2)
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
-          versionMaintenance=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
+          versionMaintenance=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}\.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
           rm -rf linux
           maintenanceBranch=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
           echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})

--- a/.github/workflows/kernel-releases-main.yml
+++ b/.github/workflows/kernel-releases-main.yml
@@ -16,7 +16,7 @@ jobs:
           KV_MAIN: "5.10"
         run: |
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
-          versionMain=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
+          versionMain=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}\.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
           rm -rf linux
           echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
           echo ::set-output name=BASE_BRANCH_MAIN::main

--- a/.github/workflows/kernel-releases-main.yml
+++ b/.github/workflows/kernel-releases-main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch latest Kernel release
         id: fetch-latest-release
         env:
-          KV_MAIN: 5.10
+          KV_MAIN: "5.10"
         run: |
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
           versionMain=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           KV_MAIN=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image_packages.txt" | grep -o 'coreos-kernel.*' | cut -d '-' -f 3- | cut -d . -f 1-2)
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
-          versionMaintenance=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
+          versionMaintenance=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_MAIN}\.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
           rm -rf linux
           maintenanceBranch=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
           echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -16,7 +16,7 @@ pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 # Get the original runc version, including official releases and rc versions.
 # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
 # so that sort -V can give the newest version including non-rc versions.
-VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | sed '/-/!{s/$/_/}' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
+VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*\.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | sed '/-/!{s/$/_/}' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   echo "already the latest Runc, nothing to do"
   UPDATE_NEEDED=0

--- a/.github/workflows/runc-releases-main.yml
+++ b/.github/workflows/runc-releases-main.yml
@@ -17,7 +17,7 @@ jobs:
           # Get the newest runc version, including official releases and rc versions.
           # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
           # so that sort -V can give the newest version including non-rc versions.
-          versionMain=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1)
+          versionMain=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*\.[0-9]*\.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1)
           commitMain="$(git -C runc rev-parse v${versionMain})"
           versionMain="${versionMain//-/_}"
           rm -rf runc

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -13,7 +13,7 @@ fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-VERSION_OLD=$(sed -n "s/^DIST rustc-\(1.[0-9]*.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
+VERSION_OLD=$(sed -n "s/^DIST rustc-\(1\.[0-9]*\.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   echo "already the latest Rust, nothing to do"
   UPDATE_NEEDED=0

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -14,7 +14,7 @@ jobs:
         id: fetch-latest-release
         run: |
           git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
-          versionMain=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1.[0-9]*.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
+          versionMain=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1\.[0-9]*\.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
           rm -rf rust
           echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
           echo ::set-output name=BASE_BRANCH_MAIN::main


### PR DESCRIPTION
1. pass env variables explicitly as string

Since Kernel 5.10, Github Actions simply stopped working.
What happens is that `KV_MAIN` gets passed as environmental variable to the inline script, but not as string but float, because it contains `.`.
Apparently the last digit of the misinterpreted float number is afterwards simply dropped by YAML parsing library used by GA.
As a result, `KV_MAIN` becomes `5.1` instead of `5.10`, `versionMain` becomes simply `5.10`, not `5.10.6`.
Then in the next steps, both `VERSION_NEW` and `VERSION_OLD` become `5.10`, and the script thinks it is already the latest version, so simply does not create a new pull request.

Simply set `KV_MAIN` or others explicitly as strings, by adding quotes, to avoid such issues.

2. Sscape dot correctly in sed expressions

So far all sed expressions have used correct regular expressions around semantic versions, around `.`.
As a result, they matched strings even without correct dots in place.
We need to escape the dot correctly.