### PR TITLE
dev-util/bsdiff: fix heap overflow vulnerability CVE-2020-14315

### DIFF
--- a/dev-util/bsdiff/bsdiff-4.3-r8.ebuild
+++ b/dev-util/bsdiff/bsdiff-4.3-r8.ebuild
@@ -18,8 +18,10 @@ RDEPEND="app-arch/bzip2"
 
 PATCHES=(
 	"${FILESDIR}/${P}-CVE-2014-9862.patch"
-	# Flatcar: Apply patch to change suffix sort to sais-lite
+	# Flatcar: Apply patch to change suffix sort to sais-lite, and
+	# to fix heap overflow vulnerability CVE-2020-14315.
 	"${FILESDIR}/${PV}_bsdiff-convert-to-sais-lite-suffix-sort.patch"
+	"${FILESDIR}/${P}-CVE-2020-14315.patch"
 )
 
 src_compile() {

--- a/dev-util/bsdiff/files/bsdiff-4.3-CVE-2020-14315.patch
+++ b/dev-util/bsdiff/files/bsdiff-4.3-CVE-2020-14315.patch
@@ -1,0 +1,22 @@
+--- a/bspatch.c	2021-01-11 15:53:32.642707355 +0100
++++ b/bspatch.c	2021-01-11 16:00:14.704637769 +0100
+@@ -35,6 +35,7 @@
+ #include <err.h>
+ #include <unistd.h>
+ #include <fcntl.h>
++#include <limits.h>
+ 
+ static off_t offtin(u_char *buf)
+ {
+@@ -152,8 +153,9 @@
+ 		};
+ 
+ 		/* Sanity-check */
+-		if ((ctrl[0] < 0) || (ctrl[1] < 0))
+-			errx(1,"Corrupt patch\n");
++		if (ctrl[0] < 0 || ctrl[0] > INT_MAX ||
++		    ctrl[1] < 0 || ctrl[1] > INT_MAX)
++			errx(1, "Corrupt patch\n");
+ 
+ 		/* Sanity-check */
+ 		if(newpos+ctrl[0]>newsize)


### PR DESCRIPTION
Fix a heap overflow vulnerability in bspatch included in bsdiff.

Originally the security issue was published as [FreeBSD-SA-16:29](https://www.freebsd.org/security/advisories/FreeBSD-SA-16:29.bspatch.asc), which pointed to a FreeBSD [patch](https://security.freebsd.org/patches/SA-16:29/bspatch.patch).
However, the patch was a set of huge changes including other unrelated changes.
That's why it was not simple at all to apply the patch to bsdiff.
Both Gentoo and Flatcar have not included the fix.

Fortunately X41 D-SEC [examined](https://www.x41-dsec.de/security/news/working/research/2020/07/15/bspatch/) the issue again, and nailed down to a simple patch that can be easily applied to other trees.
We simply take the patch with minimal changes.

See also [CVE-2020-14315](https://nvd.nist.gov/vuln/detail/CVE-2020-14315).

## How to use

```
emerge-amd64-usr dev-util/bsdiff
```

## Testing done

CI passed. http://localhost:9091/job/os/job/manifest/1773/cldsv/