### PR TITLE
dev-lang/rust: Fix patch name

### DIFF
--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -120,7 +120,7 @@ PATCHES=(
 	"${FILESDIR}"/1.46.0-don-t-create-prefix-at-time-of-check.patch
 	"${FILESDIR}"/1.47.0-ignore-broken-and-non-applicable-tests.patch
 	"${FILESDIR}"/1.47.0-llvm-tensorflow-fix.patch
-	"${FILESDIR}"/1.48.0-gentoo-musl-target-specs.patch
+	"${FILESDIR}"/1.49.0-gentoo-musl-target-specs.patch
 )
 
 S="${WORKDIR}/${MY_P}-src"


### PR DESCRIPTION
I renamed the file in the previous commit (after running the CI), and forgot I needed to also rename it in the list of patches :-/
