### PR TITLE
dev-libs/openssl: Drop bindist from RESTRICT variable

### DIFF
--- a/dev-libs/openssl/openssl-1.1.1g.ebuild
+++ b/dev-libs/openssl/openssl-1.1.1g.ebuild
@@ -32,7 +32,7 @@ SLOT="0/1.1" # .so version of libssl/libcrypto
 [[ "${PV}" = *_pre* ]] || \
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~x86-linux"
 IUSE="+asm bindist elibc_musl rfc3779 sctp cpu_flags_x86_sse2 sslv3 static-libs test tls-heartbeat vanilla zlib"
-RESTRICT="!bindist? ( bindist )
+RESTRICT="
 	!test? ( test )"
 
 RDEPEND=">=app-misc/c_rehash-1.7-r1


### PR DESCRIPTION
It's really a hindrance during bootstrap, and we would be looking into
ways of making an exception for openssl anyway. Using
package.accept_restrict file does not do the trick, apparently because
of catalyst using its own portage config.

This came up during building SDK stage1 with new portage. The error was like:

```
!!! All ebuilds that could satisfy "dev-libs/openssl:0=" for /tmp/stage1root/ have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-libs/openssl-1.1.1g::coreos (masked by: bindist in RESTRICT)
```

It either stopped being racy with new portage or was simply quite much more likely to be triggered. With restriction removed, the build went further.

On a second thought, this restrict didn't make sense to me, because the logic behind this restrict is "if you disable bindist USE flag, then add bindist to RESTRICT", while I think it should be more like "if you enable bindist USE flag then add bindist to RESTRICT too". My reasoning is that bindist USE flag causes openssl to contain some possibly patent-encumbered algorithms, so they obviously make distribution of openssl unclear, thus it should be restricted. And to acknowledge the restriction, one should add bindist to ACCEPT_RESTRICT somewhere. So either I understood things wrong, or it's a bug in openssl packaging. I could file a bug in gentoo tracker about this.