### PR TITLE
profiles: disable cxx for net-libs/nghttp2

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -116,3 +116,7 @@ sys-kernel/coreos-firmware -savedconfig
 
 # Make kmod support kernel modules compressed via lzma(xz)
 sys-apps/kmod lzma
+
+# net-libs/nghttp2 should be built with -cxx to avoid issues with boost 1.65.
+# configure script is not able to check if Boost:ASIO library exists.
+net-libs/nghttp2 -cxx


### PR DESCRIPTION
When building `net-libs/nghttp2` needed by curl 7.74, build fails when checking for prerequisites of boost libs.

```
configure:20402: checking whether the Boost::ASIO library is available
configure:20433: x86_64-cros-linux-gnu-g++ -std=c++14 -c -O2 -pipe -mtune=generic -g   conftest.cpp >&5
configure:20433: $? = 0
configure:20447: result: yes
configure:20540: error: Could not find a version of the library!
```

To avoid such issues, we should disable the `cxx` USE flag for `net-libs/nghttp2`.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/137.

## How to use

```
emerge-amd64-usr net-misc/curl
```

## Testing done

CI passed http://localhost:9091/job/os/job/manifest/1816/cldsv/
