### PR TITLE
app-emulation/open-vmdk: Update

### DIFF
--- a/app-emulation/open-vmdk/open-vmdk-1.0.ebuild
+++ b/app-emulation/open-vmdk/open-vmdk-1.0.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="Tool to convert vmdk to an ova file"
 HOMEPAGE="https://github.com/vmware/open-vmdk"
@@ -13,13 +13,13 @@ SLOT="0"
 
 EGIT_REPO_URI="https://github.com/vmware/open-vmdk"
 EGIT_BRANCH="master"
-EGIT_COMMIT="82eb7268e78cc32907573b713569e1331c571ce5"
+EGIT_COMMIT="fed311f0529333efb42a289dc864d1ea9f59ebfa"
 
 KEYWORDS="amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="app-misc/jq ${DEPEND}"
+RDEPEND="${DEPEND}"
 
 src_install() {
 	emake DESTDIR="${D}" install


### PR DESCRIPTION
Replace the use of deprecated git eclass with git-r3 and bump the
commit version to latest version. This version dropped a dependency on
jq.

It is a breaking change for users of mkova.sh, since it has changed
the order of parameters to allow passing multiple vmdk files to it.

I have made this commit for the portage update and it has pushed the build further.

I haven't found any use of the `mkova.sh` script in jenkins or build scripts. I haven't found any use of `vmdk-converter` anywhere either, so not sure why this package needs to be a part of SDK. But this is something to investigate later.

Test build: http://localhost:9091/job/os/job/manifest/1831/cldsv/