### PR TITLE
sys-apps/systemd: Fix the DefaultTasksMax patch to default to 100%

### DIFF
--- a/sys-apps/systemd/files/0007-core-use-max-for-DefaultTasksMax.patch
+++ b/sys-apps/systemd/files/0007-core-use-max-for-DefaultTasksMax.patch
@@ -8,24 +8,27 @@ to 512, later 15% of the system's maximum number of PIDs.  This
 limit is low and a change in behavior that people running services
 in containers will hit frequently, so revert to previous behavior.
 ---
- man/systemd-system.conf.xml | 2 +-
+ man/systemd-system.conf.xml | 5 +----
  src/basic/cgroup-util.h     | 4 ++++
  src/core/system.conf.in     | 2 +-
- 3 files changed, 6 insertions(+), 2 deletions(-)
+ 3 files changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/man/systemd-system.conf.xml b/man/systemd-system.conf.xml
-index 0dea50f2fe..3847118881 100644
+index 0dea50f2fe..bcbed4cf59 100644
 --- a/man/systemd-system.conf.xml
 +++ b/man/systemd-system.conf.xml
-@@ -361,7 +361,7 @@
+@@ -361,10 +361,7 @@
          <listitem><para>Configure the default value for the per-unit <varname>TasksMax=</varname> setting. See
          <citerefentry><refentrytitle>systemd.resource-control</refentrytitle><manvolnum>5</manvolnum></citerefentry>
          for details. This setting applies to all unit types that support resource control settings, with the exception
 -        of slice units. Defaults to 15% of the sysctl setting <varname>kernel.pid_max=</varname> or root cgroup <varname>pids.max</varname>.
+-        Kernel has a default value for <varname>kernel.pid_max=</varname> and an algorithm of counting in case of more than 32 cores.
+-        For example with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 4915,
+-        but might be greater in other systems or smaller in OS containers.</para></listitem>
 +        of slice units. Defaults to 100%.</para></listitem>
-         Kernel has a default value for <varname>kernel.pid_max=</varname> and an algorithm of counting in case of more than 32 cores.
-         For example with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 4915,
-         but might be greater in other systems or smaller in OS containers.</para></listitem>
+       </varlistentry>
+
+       <varlistentry>
 diff --git a/src/basic/cgroup-util.h b/src/basic/cgroup-util.h
 index bdc0d0d086..345a99aa5c 100644
 --- a/src/basic/cgroup-util.h


### PR DESCRIPTION
# sys-apps/systemd: Fix the DefaultTasksMax patch to default to 100%

Updated the patch to remove some more uneccesary text related to DefaultTasksMax

# How to use

```bash
emerge-amd64-usr sys-apps/systemd
./build_image
```

# Testing done

[Jenkins](http://localhost:9091/job/os/job/manifest/1855/cldsv/) build is running.

