### PR TITLE
Drop libnih

### DIFF
--- a/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
+++ b/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
@@ -66,8 +66,6 @@ RDEPEND="${RDEPEND}
 	net-misc/google-cloud-sdk
 	sys-apps/usbutils
 	sys-apps/systemd
-	!sys-apps/nih-dbus-tool
-	sys-libs/libnih
 	sys-libs/nss-usrfiles
 	sys-power/iasl
 	virtual/udev

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -4,7 +4,6 @@
 
 =dev-util/shflags-1.0.3 ~amd64
 =dev-util/perf-4.9.13 ~amd64
-=sys-libs/libnih-1.0.3 ~amd64
 
 # Everything needed for the boot engine
 >=sys-apps/kexec-tools-2.0.4-r1 ~amd64


### PR DESCRIPTION
It's unused. Used to be a dependency of ureadahead and upstart, which got dropped long time ago. I noticed it during updating portage by updating profiles, since gentoo is about to drop the library too and masked it.

To be merged together with https://github.com/kinvolk/portage-stable/pull/139.

Test build succeeded: http://localhost:9091/job/os/job/manifest/1860/cldsv/