### PR TITLE
coreos-base,profiles: delete nss

### DIFF
--- a/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
+++ b/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
@@ -28,7 +28,6 @@ DEPEND="
 	coreos-devel/kola-data
 	coreos-devel/mantle
 	dev-libs/gobject-introspection
-	dev-libs/nss
 	dev-python/setuptools
 	dev-util/boost-build
 	dev-util/catalyst

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -19,7 +19,6 @@
 =dev-libs/libpcre2-10.30 ~arm64
 =dev-libs/libpcre-8.41 ~arm64
 =dev-libs/libusb-1.0.21 ~arm64
-=dev-libs/nss-3.29.5 ~arm64
 =dev-libs/userspace-rcu-0.9.1 **
 =dev-perl/libintl-perl-1.240.0-r2 ~arm64
 =dev-perl/Text-Unidecode-1.270.0 ~arm64

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -5,7 +5,6 @@
 
 app-arch/tar		minimal
 app-crypt/mit-krb5	-keyutils
-dev-libs/nss		utils
 dev-libs/dbus-glib	tools
 dev-libs/protobuf 	-python
 dev-libs/libxml2	-python

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -6,7 +6,6 @@ app-editors/vim		minimal
 dev-lang/python		-berkdb gdbm
 dev-libs/dbus-glib	tools
 dev-libs/elfutils	-utils
-dev-libs/nss		-utils
 dev-libs/openssl	pkcs11
 dev-util/perf		-doc -demangle -tui -ncurses -perl -python
 dev-util/perf-next	-doc -demangle -tui -ncurses -perl -python
@@ -34,9 +33,6 @@ dev-util/pkgconfig internal-glib
 
 # minimize risk removing unneeded patches and networking support
 app-shells/bash -net vanilla
-
-# disable nss utilities
-dev-libs/nss -utils
 
 # needed by docker
 sys-libs/libseccomp static-libs


### PR DESCRIPTION
As `dev-libs/nss` is not used anywhere, let's simply remove nss.
The only ebuild that pulls in is `net-misc/curl`, but only if the USE flag `nss` is enabled.
As the `nss` flag is disabled for curl, we do not need to keep `dev-libs/nss` at all.

According to the change, delete `dev-libs/nss` from profiles and sdk-depends.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/141 .

## How to use

```
./bootstrap_sdk
./build_packages
...
```

## Testing done

CI passed http://localhost:9091/job/os/job/manifest/1877/cldsv/