### PR TITLE
sys-block/open-iscsi: Command substition in iscsi-init system service

### DIFF
--- a/sys-block/open-iscsi/files/iscsi-init.service
+++ b/sys-block/open-iscsi/files/iscsi-init.service
@@ -6,4 +6,4 @@ ConditionPathExists=!/etc/iscsi/initiatorname.iscsi
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`/usr/sbin/iscsi-iname`" > /etc/iscsi/initiatorname.iscsi'
+ExecStart=/usr/bin/sh -c 'echo "InitiatorName=$(/usr/sbin/iscsi-iname)" > /etc/iscsi/initiatorname.iscsi'


### PR DESCRIPTION
# sys-block/open-iscsi: Command substition in iscsi-init system service

https://github.com/kinvolk/coreos-overlay/pull/791/files#r563735720

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# How to use
```
emerge-amd64-usr open-iscsi
```

# Testing done

Done locally, need to schedule a Jenkins build

