### PR TITLE
app-admin/sudo: remove perl dependency

### DIFF
--- a/app-admin/sudo/sudo-1.9.5_p2.ebuild
+++ b/app-admin/sudo/sudo-1.9.5_p2.ebuild
@@ -51,11 +51,14 @@ DEPEND="
 	)
 	sssd? ( sys-auth/sssd[sudo] )
 "
+
+# Flatcar: remove perl runtime dependency
+#    ldap? ( dev-lang/perl )
+
 RDEPEND="
 	${DEPEND}
 	>=app-misc/editor-wrapper-3
 	virtual/editor
-	ldap? ( dev-lang/perl )
 	pam? ( sys-auth/pambase )
 	selinux? ( sec-policy/selinux-sudo )
 	sendmail? ( virtual/mta )
@@ -194,8 +197,9 @@ src_install() {
 		doins "${T}"/ldap.conf.sudo
 		fperms 0440 /etc/ldap.conf.sudo
 
-		insinto /etc/openldap/schema
-		newins doc/schema.OpenLDAP sudo.schema
+		# Flatcar: we don't ship openldap schemas
+		#insinto /etc/openldap/schema
+		#newins doc/schema.OpenLDAP sudo.schema
 	fi
 	if use pam; then
 		pamd_mimic system-auth sudo auth account session


### PR DESCRIPTION
This Flatcar specific change to the sudo ebuild was missed when updating to sudo-1.9.5p2.

# Testing done
Unmerged perl, emerged sudo, and sudo chrooted into the cross root to run sudo there, validating it runs w/o perl.
```
$ emerge-amd64-usr --unmerge perl
$ emerge-amd64-usr sudo
$ sudo chroot /build/amd64-usr/ sudo ls
bin  boot  build  dev  etc  home  lib  lib64  media  mnt  opt  packages  proc  root  run  sbin  sys  tmp  usr  var
```

# Cherry pick
Cherry pick to 2605, 2705, 2765.