### PR TITLE
app-crypt/trousers: use correct file permissions

### DIFF
--- a/app-crypt/trousers/files/tmpfiles.d/trousers.conf
+++ b/app-crypt/trousers/files/tmpfiles.d/trousers.conf
@@ -1,3 +1,3 @@
 d /var/lib/tpm 0755 tss tss - -
-C /etc/tcsd.conf 0600 tss tss - /usr/share/trousers/tcsd.conf
+C /etc/tcsd.conf 0640 root tss - /usr/share/trousers/tcsd.conf
 C /var/lib/tpm/system.data 0600 tss tss - /usr/share/trousers/system.data

--- a/app-crypt/trousers/trousers-0.3.14-r2.ebuild
+++ b/app-crypt/trousers/trousers-0.3.14-r2.ebuild
@@ -67,7 +67,7 @@ src_install() {
 	use doc && dodoc doc/*
 	# Flatcar:
 	# (removed newinitd and newconfd)
-	fowners tss:tss /etc/tcsd.conf
+	fowners root:tss /etc/tcsd.conf
 
 	systemd_dounit "${FILESDIR}"/tcsd.service
 
@@ -84,6 +84,6 @@ src_install() {
 	# stash a copy of the config so we can restore it from tmpfiles
 	doins "${D}"/etc/tcsd.conf
 	fowners tss:tss /usr/share/trousers/system.data
-	fowners tss:tss /usr/share/trousers/tcsd.conf
+	fowners root:tss /usr/share/trousers/tcsd.conf
 	systemd_dotmpfilesd "${FILESDIR}"/tmpfiles.d/trousers.conf
 }


### PR DESCRIPTION
The security patch that was brought in has stricter permission checks
which cause the service to fail:
ERROR: TCSD config file (/etc/tcsd.conf) must be user/group root/tss
Set the expected file ownership and permissions.

https://github.com/kinvolk/Flatcar/issues/335

**Note:** will be picked for all channels

# How to use


# Testing done

I ran this [build](http://localhost:9091/job/os/job/manifest/1916/) and saw that the service is running successfully:

```
$ systemctl status tcsd
● tcsd.service - TCG Core Services Daemon
     Loaded: loaded (/usr/lib/systemd/system/tcsd.service; disabled; vendor preset: disabled)
     Active: active (running) since Fri 2021-01-29 18:16:47 UTC; 1min 59s ago
   Main PID: 1027 (tcsd)
      Tasks: 1 (limit: 38274)
     Memory: 760.0K
     CGroup: /system.slice/tcsd.service
             └─1027 /usr/sbin/tcsd -f

Jan 29 18:16:47 hostname systemd[1]: Started TCG Core Services Daemon.
$ journalctl -u tcsd
-- Journal begins at Fri 2021-01-29 18:16:21 UTC, ends at Fri 2021-01-29 18:19:25 UTC. --
Jan 29 18:16:47 hostname systemd[1]: Started TCG Core Services Daemon.
```