### PR TITLE
coreos-base/coreos-init: Show OEM in motd

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="959ca2e599d29eaa6193bd7dd6a6e3fa3e9e1617" # flatcar-master
+	CROS_WORKON_COMMIT="cdfee3f8a54b995eed52e93280b231a93f2e1013" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/coreos-base/oem-azure-pro/files/oem-release
+++ b/coreos-base/oem-azure-pro/files/oem-release
@@ -1,5 +1,5 @@
 ID=azure
 VERSION_ID=@@OEM_VERSION_ID@@
-NAME="Microsoft Azure"
+NAME="Microsoft Azure (Pro)"
 HOME_URL="https://azure.microsoft.com/"
 BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
@@ -29,7 +29,11 @@ S="${WORKDIR}"
 src_prepare() {
 	if use ec2 || use aws_pro ; then
 		ID="ami"
-		NAME="Amazon EC2"
+		if use ec2; then
+			NAME="Amazon EC2"
+		else
+			NAME="Amazon EC2 (Pro)"
+		fi
 		HOME_URL="http://aws.amazon.com/ec2/"
 	elif use openstack ; then
 		ID="openstack"


### PR DESCRIPTION
- coreos-base/coreos-init: Show OEM in motd
  This pulls in https://github.com/kinvolk/init/pull/34
- coreos-base/oem-*: add Pro to OEM name where applicable 
  Using the change in https://github.com/kinvolk/init/pull/34
  we can show the OEM on the motd, and by including "Pro" in the OEM
  name we can also show whether it is a Pro image or not. Later this
  may be revisited if the /usr/../os-release file is the place for it.

# How to use

Build an OEM image and see the motd after login

# Testing done

None