### PR TITLE
coreos-base/coreos: Move nvidia-metadata to amd64-only RDEPENDS

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -83,6 +83,7 @@ RDEPEND="${RDEPEND}
 		net-fs/cifs-utils
 		sys-auth/realmd
 		sys-auth/sssd
+		x11-drivers/nvidia-metadata
 	)"
 
 RDEPEND="${RDEPEND}
@@ -171,7 +172,6 @@ RDEPEND="${RDEPEND}
 	sys-libs/timezone-data
 	sys-process/lsof
 	sys-process/procps
-	x11-drivers/nvidia-metadata
 "
 
 # OEM specific bits that need to go in USR


### PR DESCRIPTION
x11-drivers/nvidia-drivers are installed only on amd64 arch, so
install x11-drivers/nvidia-metadata also only on amd64.

Test build: http://localhost:9091/job/os/job/manifest/1964/