### PR TITLE
coreos-base/coreos-init: make wget more resilient in flatcar-install

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="cdfee3f8a54b995eed52e93280b231a93f2e1013" # flatcar-master
+	CROS_WORKON_COMMIT="82a878b1cc2a0d0c41630017b8fe68b33893bf15" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/35
to add parameters for wget in bin/flatcar-install.

# How to use


# Testing done

