### PR TITLE
sys-kernel/dracut: Drop the use of mirror://kernel

### DIFF
--- a/sys-kernel/dracut/dracut-044-r1.ebuild
+++ b/sys-kernel/dracut/dracut-044-r1.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info multilib systemd
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 ~arm ia64 ppc ~ppc64 sparc x86"

--- a/sys-kernel/dracut/dracut-044-r3.ebuild
+++ b/sys-kernel/dracut/dracut-044-r3.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info toolchain-funcs systemd
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"

--- a/sys-kernel/dracut/dracut-045-r2.ebuild
+++ b/sys-kernel/dracut/dracut-045-r2.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info toolchain-funcs systemd
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 ~arm ia64 ~mips ppc ~ppc64 sparc x86"

--- a/sys-kernel/dracut/dracut-046-r1.ebuild
+++ b/sys-kernel/dracut/dracut-046-r1.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info toolchain-funcs systemd
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 ~arm ia64 ~mips ppc ~ppc64 sparc x86"

--- a/sys-kernel/dracut/dracut-047-r1.ebuild
+++ b/sys-kernel/dracut/dracut-047-r1.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info systemd toolchain-funcs
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-kernel/dracut/dracut-048-r1.ebuild
+++ b/sys-kernel/dracut/dracut-048-r1.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info systemd toolchain-funcs
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-kernel/dracut/dracut-048.ebuild
+++ b/sys-kernel/dracut/dracut-048.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1 eutils linux-info systemd toolchain-funcs
 
 DESCRIPTION="Generic initramfs generation tool"
 HOMEPAGE="https://dracut.wiki.kernel.org"
-SRC_URI="mirror://kernel/linux/utils/boot/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The kernel mirror was dropped from the thirdpartymirrors file in
profiles, so it's use needs to be replaced with an address to
kernel.org.

It's a quick hack to fix the issue without spending too much time on updating every single package. The change in SRC_URIs were done with `sed -i'' -e 's!mirror://kernel!https://www.kernel.org/pub!g' $(git grep 'mirror://kernel' | cut -f1 -d: | grep -e '\.\(eclass\|ebuild\)$' | sort -u)`.

Needs to be merged together with https://github.com/kinvolk/portage-stable/pull/148.

Test build: http://localhost:9091/job/os/job/manifest/2062/