### PR TITLE
coreos-base/coreos-init: SSHD: use secure crypto algos only

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="82a878b1cc2a0d0c41630017b8fe68b33893bf15" # flatcar-master
+	CROS_WORKON_COMMIT="4d064e7755fea10bc89e0d42ad8f575ba87a5b22" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This change updates coreos-init to a version which includes
a new SSHD config to limit crypto to "known secure" algorithms only.

See https://github.com/kinvolk/init/pull/36 for details.

**Note** that I'll update this PR to point to the merge commit of the [source PR](https://github.com/kinvolk/init/pull/36) when that one gets merged. Bringing up this PR early so it can be reviewed in parallel to the source PR.

# Testing done

```
$ emerge-amd64-usr coreos-init
$ ./build_image --board=amd64-usr
$ ./image_to_vm.sh ...
```
Started QEmu image, SSH'd into image, then
```
core@localhost ~ $ sudo cat /etc/ssh/sshd_config 
# Use most defaults for sshd configuration.
Subsystem sftp internal-sftp
ClientAliveInterval 180
UseDNS no
UsePAM yes
PrintLastLog no # handled by PAM
PrintMotd no # handled by PAM
Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128-etm@openssh.com,umac-128@openssh.com
KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
```

# Impact
While this change is not expected to have a noticeable impact to the vast majority of users, some ancient clients which only offer (by today's standards) insecure ciphers may be affected. We need to raise this in our release communication.