### PR TITLE
app-admin/etcd-wrapper: use docker for the etcd service and drop etcd-wrapper

### DIFF
--- a/app-admin/etcd-wrapper/etcd-wrapper-3.3.25.ebuild
+++ b/app-admin/etcd-wrapper/etcd-wrapper-3.3.25.ebuild
@@ -14,7 +14,8 @@ IUSE=""
 SLOT=0
 
 DEPEND=""
-RDEPEND=">=app-emulation/rkt-1.9.1[rkt_stage1_fly]"
+
+RDEPEND=">=app-admin/sdnotify-proxy-0.1.0"
 
 S=${WORKDIR}
 

--- a/app-admin/etcd-wrapper/files/etcd-member.service
+++ b/app-admin/etcd-wrapper/files/etcd-member.service
@@ -8,21 +8,22 @@ Conflicts=etcd2.service
 
 [Service]
 Type=notify
-Restart=on-failure
+NotifyAccess=all
+Restart=always
 RestartSec=10s
 TimeoutStartSec=0
 LimitNOFILE=40000
 
+Environment="ETCD_IMAGE_URL=quay.io/coreos/etcd"
 Environment="ETCD_IMAGE_TAG=@ETCD_IMAGE_TAG@"
 Environment="ETCD_NAME=%m"
 Environment="ETCD_USER=etcd"
 Environment="ETCD_DATA_DIR=/var/lib/etcd"
-Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/flatcar/etcd-member-wrapper.uuid"
+Environment="ETCD_SSL_DIR=/etc/ssl/certs"
 
-ExecStartPre=/usr/bin/mkdir --parents /var/lib/flatcar
-ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/flatcar/etcd-member-wrapper.uuid
 ExecStart=/usr/lib/flatcar/etcd-wrapper $ETCD_OPTS
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/flatcar/etcd-member-wrapper.uuid
+ExecStop=/usr/bin/docker stop etcd-member
+ExecStopPost=/usr/bin/docker rm etcd-member
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/etcd-wrapper/files/etcd-wrapper
+++ b/app-admin/etcd-wrapper/files/etcd-wrapper
@@ -1,87 +1,25 @@
-#!/usr/bin/bash -e
-# Wrapper for launching etcd via rkt.
-#
-# Make sure to set ETCD_IMAGE_TAG to an image tag published here:
-# https://quay.io/repository/coreos/etcd?tab=tags Alternatively,
-# override ETCD_IMAGE to a custom image.
-
-function require_ev_all() {
-	for rev in $@ ; do
-		if [[ -z "${!rev}" ]]; then
-			echo ${rev} is not set
-			exit 1
-		fi
-	done
-}
-
-function require_ev_one() {
-	for rev in $@ ; do
-		if [[ ! -z "${!rev}" ]]; then
-			return
-		fi
-	done
-	echo One of $@ must be set
-	exit 1
-}
-
-require_ev_one ETCD_IMAGE ETCD_IMAGE_TAG
-require_ev_all ETCD_USER ETCD_DATA_DIR
-
-ETCD_IMAGE_URL="${ETCD_IMAGE_URL:-docker://quay.io/coreos/etcd}"
-ETCD_IMAGE="${ETCD_IMAGE:-${ETCD_IMAGE_URL}:${ETCD_IMAGE_TAG}}"
-
-if [[ "${ETCD_IMAGE%%/*}" == "quay.io" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q trust-keys-from-https); then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
-elif [[ "${ETCD_IMAGE%%/*}" == "docker:" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q insecure-options); then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} --insecure-options=image"
-fi
-
-if [[ ! -e "${ETCD_DATA_DIR}" ]]; then
-	mkdir --parents "${ETCD_DATA_DIR}"
-	chown "${ETCD_USER}" "${ETCD_DATA_DIR}"
-fi
+#!/bin/bash
+# The "etcd-wrapper" script can't be deleted because ct overwrites
+# the ExecStart directive with etcd-wrapper. Do the new action of
+# ExecStart here.
+set -e
 
 # Do not pass ETCD_DATA_DIR through to the container. The default path,
 # /var/lib/etcd is always used inside the container.
 etcd_data_dir="${ETCD_DATA_DIR}"
 ETCD_DATA_DIR="/var/lib/etcd"
-
-ETCD_SSL_DIR="${ETCD_SSL_DIR:-/etc/ssl/certs}"
-
-SYSTEMD_SYSTEM_DIR_SRC="${SYSTEMD_SYSTEM_DIR_SRC:-/run/systemd/system}"
-if [[ -d "${SYSTEMD_SYSTEM_DIR_SRC}" ]]; then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
-		--mount volume=coreos-systemd-dir,target=/run/systemd/system \
-		--volume coreos-systemd-dir,kind=host,source=${SYSTEMD_SYSTEM_DIR_SRC},readOnly=true \
-	"
-fi
-
-if [[ -S "${NOTIFY_SOCKET}" ]]; then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
-		--mount volume=coreos-notify,target=/run/systemd/notify \
-		--volume coreos-notify,kind=host,source=${NOTIFY_SOCKET} \
-		--set-env=NOTIFY_SOCKET=/run/systemd/notify \
-	"
-fi
-
-RKT="${RKT:-/usr/bin/rkt}"
-RKT_STAGE1_ARG="${RKT_STAGE1_ARG:---stage1-from-dir=stage1-fly.aci}"
-set -x
-exec ${RKT} ${RKT_GLOBAL_ARGS} \
-	run ${RKT_RUN_ARGS} \
-	--volume coreos-data-dir,kind=host,source="${etcd_data_dir}",readOnly=false \
-	--volume coreos-etc-ssl-certs,kind=host,source="${ETCD_SSL_DIR}",readOnly=true \
-	--volume coreos-usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
-	--volume coreos-etc-hosts,kind=host,source=/etc/hosts,readOnly=true \
-	--volume coreos-etc-resolv,kind=host,source=/etc/resolv.conf,readOnly=true \
-	--mount volume=coreos-data-dir,target=/var/lib/etcd \
-	--mount volume=coreos-etc-ssl-certs,target=/etc/ssl/certs \
-	--mount volume=coreos-usr-share-certs,target=/usr/share/ca-certificates \
-	--mount volume=coreos-etc-hosts,target=/etc/hosts  \
-	--mount volume=coreos-etc-resolv,target=/etc/resolv.conf  \
-	--inherit-env \
-	${RKT_STAGE1_ARG} \
-	${ETCD_IMAGE} \
-		${ETCD_IMAGE_ARGS} \
-		--user=$(id -u "${ETCD_USER}") \
-		-- "$@"
+mkdir -p ${etcd_data_dir}
+chown -R etcd:etcd ${etcd_data_dir}
+chmod 700 ${etcd_data_dir}
+# A better way to run the Flannel/etcd container image is Podman because
+# Flannel depends on etcd but wants to be run before Docker so that it
+# can set up the Docker networking. Etcd and Flannel are part of the
+# Container Linux Config specification and thus can't be dropped easily.
+# For now we have to resort to running these services with Docker and try
+# to restart Docker for the Flannel options to take effect.
+/usr/bin/docker stop etcd-member || true
+/usr/bin/docker rm -f etcd-member || true
+# set umask so that sdnotify-proxy creates /run/etcd-notify with the same relaxed permissions as NOTIFY_SOCKET (/run/systemd/notify) normally has, to allow ETCD_USER to write to it
+umask 000
+# mapping only /run/etcd-notify does not work and we use the full /run, also we must set NOTIFY_SOCKET in the container but use the original for /usr/libexec/sdnotify-proxy
+/usr/libexec/sdnotify-proxy /run/etcd-notify /usr/bin/docker run --name etcd-member --network=host --ipc=host -u $(id -u ${ETCD_USER}):$(id -g ${ETCD_USER}) -v /run:/run -v /usr/share/ca-certificates:/usr/share/ca-certificates:ro -v ${etcd_data_dir}:/var/lib/etcd:rw -v ${ETCD_SSL_DIR}:/etc/ssl/certs:ro --env-file <(env; echo PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; echo NOTIFY_SOCKET=/run/etcd-notify) --entrypoint /usr/local/bin/etcd ${ETCD_IMAGE:-${ETCD_IMAGE_URL}:${ETCD_IMAGE_TAG}} "$@"

--- a/app-admin/flannel-wrapper/files/flannel-docker-opts.service
+++ b/app-admin/flannel-wrapper/files/flannel-docker-opts.service
@@ -4,18 +4,21 @@ Documentation=https://github.com/coreos/flannel
 PartOf=flanneld.service
 Requires=flanneld.service
 After=flanneld.service
-Before=docker.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=true
+Restart=on-failure
+RestartSec=5s
 
+Environment="FLANNEL_IMAGE_URL=quay.io/coreos/flannel"
 Environment="FLANNEL_IMAGE_TAG=@FLANNEL_IMAGE_TAG@"
-Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/flatcar/flannel-wrapper2.uuid"
-Environment="FLANNEL_IMAGE_ARGS=--exec=/opt/bin/mk-docker-opts.sh"
+Environment="FLANNEL_CMD=/opt/bin/mk-docker-opts.sh"
+Environment="FLANNEL_CONTAINER=flannel-docker-opts"
 
-ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/flatcar/flannel-wrapper2.uuid
 ExecStart=/usr/lib/flatcar/flannel-wrapper -d /run/flannel/flannel_docker_opts.env -i
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/flatcar/flannel-wrapper2.uuid
+ExecStop=/usr/bin/docker stop flannel-docker-opts
+ExecStopPost=/usr/bin/docker rm flannel-docker-opts
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/flannel-wrapper/files/flannel-wrapper
+++ b/app-admin/flannel-wrapper/files/flannel-wrapper
@@ -1,86 +1,42 @@
-#!/bin/bash -e
-# Wrapper for launching flannel via rkt.
-#
-# Make sure to set FLANNEL_IMAGE_TAG to an image tag published here:
-# https://quay.io/repository/coreos/flannel?tab=tags Alternatively,
-# override FLANNEL_IMAGE to a custom image.
-
-function require_ev_all() {
-	for rev in $@ ; do
-		if [[ -z "${!rev}" ]]; then
-			echo "${rev}" is not set
-			exit 1
-		fi
-	done
-}
-
-function require_ev_one() {
-	for rev in $@ ; do
-		if [[ ! -z "${!rev}" ]]; then
-			return
-		fi
-	done
-	echo One of $@ must be set
-	exit 1
-}
-
-if [[ -n "${FLANNEL_VER}" ]]; then
-	echo FLANNEL_VER environment variable is deprecated, please use FLANNEL_IMAGE_TAG instead
-fi
-
-if [[ -n "${FLANNEL_IMG}" ]]; then
-	echo FLANNEL_IMG environment variable is deprecated, please use FLANNEL_IMAGE_URL instead
-fi
-
-FLANNEL_IMAGE_TAG="${FLANNEL_IMAGE_TAG:-${FLANNEL_VER}}"
-
-require_ev_one FLANNEL_IMAGE FLANNEL_IMAGE_TAG
-
-FLANNEL_IMAGE_URL="${FLANNEL_IMAGE_URL:-${FLANNEL_IMG:-docker://quay.io/coreos/flannel}}"
-FLANNEL_IMAGE="${FLANNEL_IMAGE:-${FLANNEL_IMAGE_URL}:${FLANNEL_IMAGE_TAG}}"
-
-if [[ "${FLANNEL_IMAGE%%/*}" == "quay.io" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q trust-keys-from-https); then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
-elif [[ "${FLANNEL_IMAGE%%/*}" == "docker:" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q insecure-options); then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} --insecure-options=image"
-fi
+#!/bin/bash
+# The "flannel-wrapper" script can't be deleted because ct overwrites
+# the ExecStart directive with flannel-wrapper. Do the new action of
+# ExecStart here.
+set -e
 
 ETCD_SSL_DIR="${ETCD_SSL_DIR:-/etc/ssl/etcd}"
+RUN_ARGS=""
 if [[ -d "${ETCD_SSL_DIR}" ]]; then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
-		--volume coreos-ssl,kind=host,source=${ETCD_SSL_DIR},readOnly=true \
-		--mount volume=coreos-ssl,target=${ETCD_SSL_DIR} \
-	"
-fi
-
-if [[ -S "${NOTIFY_SOCKET}" ]]; then
-	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
-		--mount volume=coreos-notify,target=/run/systemd/notify \
-		--volume coreos-notify,kind=host,source=${NOTIFY_SOCKET} \
-		--set-env=NOTIFY_SOCKET=/run/systemd/notify \
-	"
+	RUN_ARGS="-v ${ETCD_SSL_DIR}:${ETCD_SSL_DIR}:ro"
 fi
 
 mkdir --parents /run/flannel
 
-RKT="${RKT:-/usr/bin/rkt}"
-RKT_STAGE1_ARG="${RKT_STAGE1_ARG:---stage1-from-dir=stage1-fly.aci}"
-set -x
-exec ${RKT} ${RKT_GLOBAL_ARGS} \
-	run ${RKT_RUN_ARGS} \
-	--net=host \
-	--volume coreos-run-flannel,kind=host,source=/run/flannel,readOnly=false \
-	--volume coreos-etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
-	--volume coreos-usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
-	--volume coreos-etc-hosts,kind=host,source=/etc/hosts,readOnly=true \
-	--volume coreos-etc-resolv,kind=host,source=/etc/resolv.conf,readOnly=true \
-	--mount volume=coreos-run-flannel,target=/run/flannel \
-	--mount volume=coreos-etc-ssl-certs,target=/etc/ssl/certs \
-	--mount volume=coreos-usr-share-certs,target=/usr/share/ca-certificates \
-	--mount volume=coreos-etc-hosts,target=/etc/hosts  \
-	--mount volume=coreos-etc-resolv,target=/etc/resolv.conf \
-	--inherit-env \
-	${RKT_STAGE1_ARG} \
-	${FLANNEL_IMAGE} \
-		${FLANNEL_IMAGE_ARGS} \
-		-- "$@"
+
+WRAP=""
+if [[ -S "${NOTIFY_SOCKET}" ]]; then
+  WRAP="/usr/libexec/sdnotify-proxy /run/${FLANNEL_CONTAINER}-notify"
+fi
+
+# A better way to run the Flannel/etcd container image is Podman because
+# Flannel depends on etcd but wants to be run before Docker so that it
+# can set up the Docker networking. Etcd and Flannel are part of the
+# Container Linux Config specification and thus can't be dropped easily.
+# For now we have to resort to running these services with Docker and try
+# to restart Docker for the Flannel options to take effect (but that also
+# terminates the etcd and flannel containers, causing the services to
+# restart).
+RESTART_DOCKER=0
+if [ "${FLANNEL_CMD}" = "/opt/bin/mk-docker-opts.sh" ] && [ "$1" = "-d" ] && [ ! -f "$2" ]; then
+  # only restart Docker only on first run, propagating updates on later runs was not done before in the rkt version, so keep the behavior
+  # (which also helps to break the loop which otherwise exists because "restart docker" mentioned above)
+  RESTART_DOCKER=1
+fi
+/usr/bin/docker stop ${FLANNEL_CONTAINER} || true
+/usr/bin/docker rm -f ${FLANNEL_CONTAINER} || true
+# mapping only /run/${FLANNEL_CONTAINER}-notify does not work and we map the full /run (using /run:/run covers /run/flannel, too), also we must set NOTIFY_SOCKET in the container but use the original for /usr/libexec/sdnotify-proxy
+${WRAP} /usr/bin/docker run --name ${FLANNEL_CONTAINER} --privileged --network=host --ipc=host ${RUN_ARGS} -v /run:/run:rw -v /etc/ssl/certs:/etc/ssl/certs:ro -v /usr/share/ca-certificates:/usr/share/ca-certificates:ro --env-file <(env; echo PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; echo NOTIFY_SOCKET=/run/${FLANNEL_CONTAINER}-notify) --entrypoint ${FLANNEL_CMD} ${FLANNEL_IMAGE:-${FLANNEL_IMAGE_URL}:${FLANNEL_IMAGE_TAG}} "$@"
+if [ "${RESTART_DOCKER}" = 1 ]; then
+  systemctl restart docker
+  echo "Restarted Docker to apply Flannel options"
+fi

--- a/app-admin/flannel-wrapper/files/flanneld.service
+++ b/app-admin/flannel-wrapper/files/flanneld.service
@@ -6,22 +6,24 @@ Requires=flannel-docker-opts.service
 
 [Service]
 Type=notify
+NotifyAccess=all
 Restart=always
 RestartSec=10s
 TimeoutStartSec=300
 LimitNOFILE=40000
 LimitNPROC=1048576
 
+Environment="FLANNEL_IMAGE_URL=quay.io/coreos/flannel"
 Environment="FLANNEL_IMAGE_TAG=@FLANNEL_IMAGE_TAG@"
 Environment="FLANNEL_OPTS=--ip-masq=true"
-Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/flatcar/flannel-wrapper.uuid"
+Environment="FLANNEL_CMD=/opt/bin/flanneld"
+Environment="FLANNEL_CONTAINER=flannel"
 EnvironmentFile=-/run/flannel/options.env
 
 ExecStartPre=/sbin/modprobe ip_tables
-ExecStartPre=/usr/bin/mkdir --parents /var/lib/flatcar /run/flannel
-ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/flatcar/flannel-wrapper.uuid
 ExecStart=/usr/lib/flatcar/flannel-wrapper $FLANNEL_OPTS
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/flatcar/flannel-wrapper.uuid
+ExecStop=/usr/bin/docker stop flannel
+ExecStopPost=/usr/bin/docker rm flannel
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/flannel-wrapper/flannel-wrapper-0.12.0.ebuild
+++ b/app-admin/flannel-wrapper/flannel-wrapper-0.12.0.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	!app-admin/flannel
-	>=app-emulation/rkt-1.9.1[rkt_stage1_fly]
+	>=app-admin/sdnotify-proxy-0.1.0
 "
 
 S="$WORKDIR"


### PR DESCRIPTION
 As rkt is deprecated we need to run the Etcd and Flannel container with Docker
    or Podman. The etcd/flannel-wrapper script is based on rkt arguments and
    can't be used in a compatible way but we cannot remove it since ct
    explicitly uses it in the ExecStart directive when writing out a
    drop-in file once flannel settings are given in a Container Linux
    Config.
    A better way to run the Flannel/etcd container image is Podman because
    Flannel depends on etcd but wants to be run before Docker so that it
    can set up the Docker networking. Etcd and Flannel are part of the
    Container Linux Config specification and thus can't be removed easily.
    For now we have to resort to running these services with Docker and try
    to restart Docker for the Flannel options to take effect (but that also
    terminates the etcd and flannel containers, causing the services to
    restart).

# How to use

Run kola tests for a cloud provider, not QEMU where the tests are excluded 

A fix for the Kubernetes test is here: https://github.com/kinvolk/mantle/pull/162

Note: From now on it's not possible to specify `Requires=flanneld.service` for `docker.service` because that creates a cyclic dependency.

# Testing done

[here](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2246/cldsv/)