### PR TITLE
net-fs/samba: EAPI=7, new USE flags, remove deps on icu

### DIFF
--- a/net-fs/samba/metadata.xml
+++ b/net-fs/samba/metadata.xml
@@ -16,12 +16,16 @@
 		<flag name="client">Enables the client part</flag>
 		<flag name="cluster">Enable support for clustering</flag>
 		<flag name="dmapi">Enable support for DMAPI. This currently works only in combination with XFS.</flag>
+		<flag name="glusterfs">Enable support for Glusterfs filesystem via <pkg>sys-cluster/glusterfs</pkg></flag>
 		<flag name="gpg">Use <pkg>app-crypt/gpgme</pkg> for AD DC</flag>
 		<flag name="json">Enable json audit support through <pkg>dev-libs/jansson</pkg></flag>
 		<flag name="iprint">Enabling iPrint technology by Novell</flag>
+		<flag name="ntvfs">Enable support for NTVFS fileserver</flag>
 		<flag name="profiling-data">Enables support for collecting profiling data</flag>
 		<flag name="quota">Enables support for user quotas</flag>
+		<flag name="regedit">Enable support for regedit command-line tool</flag>
 		<flag name="snapper">Enable vfs_snapper module (requires <pkg>sys-apps/dbus</pkg>)</flag>
+		<flag name="spotlight">Enable support for spotlight backend</flag>
 		<flag name="system-heimdal">Use <pkg>app-crypt/heimdal</pkg> instead of
 			bundled heimdal.</flag>
 		<flag name="system-mitkrb5">Use <pkg>app-crypt/mit-krb5</pkg> instead of

--- a/net-fs/samba/samba-4.12.9-r2.ebuild
+++ b/net-fs/samba/samba-4.12.9-r2.ebuild
@@ -42,7 +42,7 @@ MULTILIB_WRAPPED_HEADERS=(
 
 CDEPEND="
 	>=app-arch/libarchive-3.1.2[${MULTILIB_USEDEP}]
-	dev-libs/icu:=[${MULTILIB_USEDEP}]
+	spotlight? ( dev-libs/icu:=[${MULTILIB_USEDEP}] )
 	dev-libs/libbsd[${MULTILIB_USEDEP}]
 	!minimal? ( dev-libs/libtasn1[${MULTILIB_USEDEP}] )
 	dev-libs/popt[${MULTILIB_USEDEP}]

--- a/net-fs/samba/samba-4.12.9-r2.ebuild
+++ b/net-fs/samba/samba-4.12.9-r2.ebuild
@@ -23,9 +23,10 @@ LICENSE="GPL-3"
 
 SLOT="0"
 
-IUSE="acl addc addns ads ceph client cluster cups debug dmapi fam gpg iprint
-json ldap pam profiling-data python quota selinux snapper syslog
-system-heimdal +system-mitkrb5 systemd test winbind zeroconf"
+IUSE="acl addc addns ads ceph client cluster cups debug dmapi fam glusterfs
+gpg iprint json ldap ntvfs pam profiling-data python quota +regedit selinux
+snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
+zeroconf"
 IUSE+=" +minimal"  # Flatcar: Only install libraries, not executables.
 
 MULTILIB_WRAPPED_HEADERS=(
@@ -79,15 +80,17 @@ CDEPEND="
 "
 DEPEND="${CDEPEND}
 	${PYTHON_DEPS}
-	app-text/docbook-xsl-stylesheets
 	dev-lang/perl:=
-	dev-libs/libxslt
 	>=dev-util/cmocka-1.1.3[${MULTILIB_USEDEP}]
 	net-libs/libtirpc[${MULTILIB_USEDEP}]
 	virtual/pkgconfig
 	|| (
 		net-libs/rpcsvc-proto
 		<sys-libs/glibc-2.26[rpc(+)]
+	)
+	spotlight? (
+		app-misc/tracker
+		dev-libs/glib
 	)
 	test? (
 		!system-mitkrb5? (
@@ -103,12 +106,19 @@ RDEPEND="${CDEPEND}
 	selinux? ( sec-policy/selinux-samba )
 "
 
+BDEPEND="
+	app-text/docbook-xsl-stylesheets
+	dev-libs/libxslt
+"
+
 REQUIRED_USE="
 	addc? ( python json winbind )
 	addns? ( python )
 	ads? ( acl ldap winbind )
 	cluster? ( ads )
 	gpg? ( addc )
+	ntvfs? ( addc )
+	spotlight? ( json )
 	test? ( python )
 	?? ( system-heimdal system-mitkrb5 )
 	${PYTHON_REQUIRED_USE}
@@ -201,13 +211,17 @@ multilib_src_configure() {
 		$(multilib_native_use_enable cups)
 		$(multilib_native_use_with dmapi)
 		$(multilib_native_use_with fam)
+		$(multilib_native_use_enable glusterfs)
 		$(multilib_native_use_with gpg gpgme)
 		$(multilib_native_use_with json)
 		$(multilib_native_use_enable iprint)
+		$(multilib_native_use_with ntvfs ntvfs-fileserver)
 		$(multilib_native_use_with pam)
 		$(multilib_native_usex pam "--with-pammodulesdir=${EPREFIX}/$(get_libdir)/security" '')
 		$(multilib_native_use_with quota quotas)
+		$(multilib_native_use_with regedit regedit)
 		$(multilib_native_use_enable snapper)
+		$(multilib_native_use_enable spotlight)
 		$(multilib_native_use_with syslog)
 		$(multilib_native_use_with systemd)
 		--systemd-install-services

--- a/net-fs/samba/samba-4.12.9-r2.ebuild
+++ b/net-fs/samba/samba-4.12.9-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7} )
 PYTHON_REQ_USE='threads(+),xml(+)'

--- a/net-fs/samba/samba-4.12.9-r2.ebuild
+++ b/net-fs/samba/samba-4.12.9-r2.ebuild
@@ -185,8 +185,9 @@ multilib_src_configure() {
 		bundled_libs="heimbase,heimntlm,hdb,kdc,krb5,wind,gssapi,hcrypto,hx509,roken,asn1,com_err,NONE"
 	fi
 
-	# Flatcar: Don't depend on tons of new packages with broken cross-compilation support.
-	bundled_libs=ALL
+	# Flatcar: we need only the mandatory bundled library, ldb by default.
+	# Without that, configure will fail because of a missing bundled library.
+	bundled_libs="ldb"
 
 	local myconf=(
 		--enable-fhs

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -119,3 +119,6 @@ net-libs/nghttp2 -cxx
 
 # These (qmanifest and qtegrity) are new tools and they pull even more dependencies.
 app-portage/portage-utils -qmanifest -qtegrity
+
+# Disable unnecessary regedit in samba to minimize the package size.
+net-fs/samba -regedit


### PR DESCRIPTION
Now that portage was updated to the latest version, we should update `EAPI` to 7.
It is mainly to allow ebuilds to make `BDEPEND` contain real build-time dependencies, not runtime ones.

Introduce a USE flag `spotlight`, to be able to disable the spotlight backend by default, as it is not needed by Linux.
Introduce a USE flag `rededit`, to be able to disable the rededit tool if needed.
Introduce a USE flag `glusterfs`, to be able to disable the glusterfs by default.
Introduce a USE flag `ntvfs`, to be able to disable the ntvfs-fileserver by default.
Since the `docbook-xsl-stylesheets` and `libxslt` are needed only at build time, we should move those deps to `BDEPEND`.

`dev-libs/icu` is needed only if spotlight is enabled. If not enabled, we should not pull in icu.

To minimize the size of bundled libraries of Samba, we should install only the `ldb` backend by default.

Disable unnecessary `regedit` in samba to minimize the package size.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/150 .

See also a Gentoo PR https://github.com/gentoo/gentoo/pull/19650 , which is slightly different from this one.

Fixes https://github.com/kinvolk/Flatcar/issues/346

## Testing done

CI passed http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2106/