### PR TITLE
profiles: Add multipath-tools to ACCEPT_KEYWORDS

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -60,11 +60,9 @@
 =sys-fs/btrfs-progs-4.19.1 ~arm64
 =sys-fs/cryptsetup-1.7.5 ~arm64
 =sys-fs/lsscsi-0.28 ~arm64
-=sys-fs/multipath-tools-0.6.4-r1 ~arm64
 =sys-fs/quota-4.04-r1 ~arm64
 =sys-libs/binutils-libs-2.29.1-r1 ~arm64
 =sys-libs/libcap-ng-0.7.8 ~arm64
 =virtual/krb5-0-r1 ~arm64
-=virtual/libudev-232 ~arm64
 =virtual/libusb-1-r2 ~arm64
 =virtual/perl-File-Path-2.130.0 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -88,3 +88,5 @@ dev-util/checkbashisms
 
 >=dev-util/dwarves-1.18 ~amd64
 >=dev-libs/elfutils-0.178 ~amd64
+
+=sys-fs/multipath-tools-0.8.5 ~amd64 ~arm64


### PR DESCRIPTION
# profiles: Add multipath-tools to ACCEPT_KEYWORDS

This commit also removes some redundant accept_keywords

# Testing done

Tested local and Jenkins Build http://localhost:9091/job/os/job/manifest/2115/

To be merged with kinvolk/portage-stable#151
