### PR TITLE
fix sdk bootstrap: use python3 in catalyst chroot-functions, set cros_host USE when bootstrapping

### DIFF
--- a/dev-util/catalyst/catalyst-3.0.14-r1.ebuild
+++ b/dev-util/catalyst/catalyst-3.0.14-r1.ebuild
@@ -58,6 +58,7 @@ PATCHES=(
 	"${FILESDIR}/0002-catalyst-Remove-Maintained-by-sections.patch"
 	"${FILESDIR}/0003-catalyst-Remove-unnecessary-future-imports.patch"
 	"${FILESDIR}/0004-catalyst-Use-python3-shebangs.patch"
+	"${FILESDIR}/0005-chroot-funcs-use-python3-for-debug-output.patch"
 )
 
 python_prepare_all() {

--- a/dev-util/catalyst/files/0005-chroot-funcs-use-python3-for-debug-output.patch
+++ b/dev-util/catalyst/files/0005-chroot-funcs-use-python3-for-debug-output.patch
@@ -1,0 +1,20 @@
+diff --git a/targets/support/chroot-functions.sh b/targets/support/chroot-functions.sh
+index f3727d0..e1c82c1 100755
+--- a/targets/support/chroot-functions.sh
++++ b/targets/support/chroot-functions.sh
+@@ -285,13 +285,13 @@ run_merge() {
+ }
+ 
+ show_debug() {
+-	if [ "${clst_DEBUG}" = "1" ]
++	if [ -n "${clst_DEBUG}" ]
+ 	then
+ 		unset PACKAGES
+ 		echo "DEBUG:"
+ 		echo "Profile/target info:"
+ 		echo "Profile inheritance:"
+-		python -c 'import portage; print(portage.settings.profiles)'
++		python3 -c 'import portage; print(portage.settings.profiles)'
+ 		echo
+ 		# TODO: make this work on non-portage
+ 		emerge --info

--- a/profiles/coreos/amd64/sdk/make.defaults
+++ b/profiles/coreos/amd64/sdk/make.defaults
@@ -1,3 +1,7 @@
 # Enable optimizations for common x86_64 CPUs
 CFLAGS="-O2 -pipe -mtune=generic"
 CXXFLAGS="${CFLAGS}"
+
+# add cros_host to bootstrapping USE flags so SDK / toolchains bootstrapping
+# will use vim's vimrc instead of baselayouts',
+BOOTSTRAP_USE="$BOOTSTRAP_USE cros_host"


### PR DESCRIPTION
# SDK bootstrap related fixes

This change adds the USE flag cros_host to the
SDK's make.default, as part of a larger fix for the SDK bootstrap build.
The SDK bootstrap build was broken in stage 1 since package upgrades
were allowed to leak into that phase.

We now limit stage 1 to only "known good" package ebuilds, which caused
downstream breakage from missing flags in the stage 2 SDK bootstrapping.
This change fixes that breakage.

This change further contains a patch for catalyst to explicitly call python3 in 
chroot-functions.sh for portage related debug output.

# How to use

Needed in combination with
* portage-stable: https://github.com/kinvolk/portage-stable/pull/152
* flatcar-scripts: https://github.com/kinvolk/flatcar-scripts/pull/123 (the main PR)

```
$ cork enter
$ sudo ./bootstrap_sdk
```

# Testing done

SDK CI build (manifest #2158) passed.