### PR TITLE
sdnotify: avoid the github redirect

### DIFF
--- a/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
+++ b/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/sdnotify-proxy"
+CROS_WORKON_PROJECT="kinvolk/sdnotify-proxy"
 CROS_WORKON_LOCALNAME="sdnotify-proxy"
 CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/sdnotify-proxy"


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

Background for this is that i've deleted our https://github.com/kinvolk/sdnotify-proxy and properly forked from coreos/sdnotify-proxy