### PR TITLE
app-admin/sdnotify-proxy: use git ref of new repository

### DIFF
--- a/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
+++ b/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
@@ -11,7 +11,7 @@ inherit coreos-go cros-workon
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="9b681920d011ce1ca3214a05f38edea535ad0778" # flatcar-master
+	CROS_WORKON_COMMIT="0f8ef1aa86c59fc6d54eadaffb248feaccd1018b" # master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
In https://github.com/kinvolk/coreos-overlay/pull/875 the repository
was switched to a fork from the archived upstream repository. However,
the ebuild was still using a reference to an old squashed Flatcar build
bot commit from the git-sync times that was only present in our old
repository.
Switch to a reference to the latest commit on the new repository which
in fact does not introduce any changes.

To be picked for all active branches