### PR TITLE
sys-kernel/coreos-firmware: include firmware for compressed kernel modules

### DIFF
--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -99,7 +99,7 @@ src_prepare() {
 	einfo "Scanning for files required by ${KV_FULL}"
 	echo -n > "${T}/firmware-scan"
 	local kofile fwfile failed
-	for kofile in $(find "${kernel_mods}" -name '*.ko'); do
+	for kofile in $(find "${kernel_mods}" -name '*.ko' -o -name '*.ko.xz'); do
 		for fwfile in $(modinfo --field firmware "${kofile}"); do
 			if [[ ! -e "${fwfile}" ]]; then
 				eerror "Missing firmware: ${fwfile} (${kofile##*/})"


### PR DESCRIPTION
When listing kernel modules to decide which firmware should be shipped
together with the image, we need to now list both compressed and
uncompressed module.

Fixes: kinvolk/Flatcar#359

# Testing done

CI currently running
