### PR TITLE
Add explicit paths to coreos-metadata and containerd executables in their unit files

### DIFF
--- a/app-emulation/containerd/files/containerd-1.0.0.service
+++ b/app-emulation/containerd/files/containerd-1.0.0.service
@@ -6,8 +6,8 @@ After=network.target
 [Service]
 Delegate=yes
 Environment=CONTAINERD_CONFIG=/usr/share/containerd/config.toml
-ExecStartPre=mkdir -p /run/docker/libcontainerd
-ExecStartPre=ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
+ExecStartPre=/usr/bin/mkdir -p /run/docker/libcontainerd
+ExecStartPre=/usr/bin/ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd --config ${TORCX_UNPACKDIR}${TORCX_IMAGEDIR}${CONTAINERD_CONFIG}
 KillMode=process

--- a/coreos-base/afterburn/files/coreos-metadata.service
+++ b/coreos-base/afterburn/files/coreos-metadata.service
@@ -8,7 +8,7 @@ Restart=on-failure
 RestartSec=10
 Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
-ExecStartPost=ln -fs /run/metadata/flatcar /run/metadata/coreos
+ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
 
 [Install]
 RequiredBy=metadata.target


### PR DESCRIPTION
While the execution of the unit may succeed by finding the executables
by searching the current PATH, calling `systemd-analyze verify` on the
units fails because this requires an absolute path.

Fixes: kinvolk/Flatcar#360

# Testing done

CI currently running
