### PR TITLE
Revert adding explicit path to the containerd unit

### DIFF
--- a/app-emulation/containerd/files/containerd-1.0.0.service
+++ b/app-emulation/containerd/files/containerd-1.0.0.service
@@ -6,8 +6,8 @@ After=network.target
 [Service]
 Delegate=yes
 Environment=CONTAINERD_CONFIG=/usr/share/containerd/config.toml
-ExecStartPre=/usr/bin/mkdir -p /run/docker/libcontainerd
-ExecStartPre=/usr/bin/ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
+ExecStartPre=mkdir -p /run/docker/libcontainerd
+ExecStartPre=ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd --config ${TORCX_UNPACKDIR}${TORCX_IMAGEDIR}${CONTAINERD_CONFIG}
 KillMode=process


### PR DESCRIPTION
This unit is post-processed for torcx purposes and adding absolute paths breaks execution.

Needs to be cherry picked to flatcar-2765 and flatcar-2801