### PR TITLE
coreos-base/coreos-init: use alternative interface names for virtio

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="4d064e7755fea10bc89e0d42ad8f575ba87a5b22" # flatcar-master
+	CROS_WORKON_COMMIT="d9ec12477ef514ac6c9cfd4182e3b2ede77c5963" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/38
to set predictable network interface names as alternative interface
names for virtio devices, and also add a special hardcoded ens4v1
name for GCE because the special udev rule to rename the device
stopped working after the systemd 247 update.

Note: Backport to 2765 when merging (may need a flatcar-2765 branch in `init`)

# How to use/Testing done

See https://github.com/kinvolk/init/pull/38
