### PR TITLE
coreos-base/coreos-init: use alternative interface names for virtio (flatcar-2765)

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="959ca2e599d29eaa6193bd7dd6a6e3fa3e9e1617" # flatcar-master
+	CROS_WORKON_COMMIT="c8800594b692fd9294cae66d3209491a83e581f6" # flatcar-2765
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/38
to set predictable network interface names as alternative interface
names for virtio devices, and also add a special hardcoded ens4v1
name for GCE because the special udev rule to rename the device
stopped working after the systemd 247 update.
A branch flatcar-2765 was created in the init repository to backport
only this change.

See https://github.com/kinvolk/coreos-overlay/pull/899