### PR TITLE
sys-apps/baselayout: enable pam_faillock with relaxed defaults

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="8e4cd3c28786a03cdbfb9ffd73552b1a0714aa8b" # flatcar-master
+	CROS_WORKON_COMMIT="bbe3f2589c46f61a2c9628ab5dd19e31ff651477" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/baselayout/pull/17
to enable the pam_faillock module as replacement for pam_tally2.
The "faillock" binary can be used to see the login attempts and
account lock status which before was available with the pam_tally
command. While the tally defaults did not temporarily lock the
account on wrong password login attempts, this is done by default
with faillock. However, the default behavior was relaxed to allow
more wrong attempts and have a shorter lock time span.

# How to use


# Testing done


