### PR TITLE
app-arch/zstd: Add app-arch/zstd to ACCEPT_KEYWORDS

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -90,3 +90,5 @@ dev-util/checkbashisms
 >=dev-libs/elfutils-0.178 ~amd64
 
 =sys-fs/multipath-tools-0.8.5 ~amd64 ~arm64
+
+=app-arch/zstd-1.4.9 ~amd64 ~arm64


### PR DESCRIPTION
# app-arch/zstd: Add app-arch/zstd to ACCEPT_KEYWORDS

To be merged along with https://github.com/kinvolk/portage-stable/pull/157

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# How to use
```bash
emerge-amd64-usr app-arch/zstd
```

# Testing done

Locally tested. Jenkins Build passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2284/

