### PR TITLE
dev-libs/openssl: Add the patch for openssl-1.1.1k release

### DIFF
--- a/dev-libs/openssl/files/openssl-1.1.1k-ca-certificate-check-bypass-fix.patch
+++ b/dev-libs/openssl/files/openssl-1.1.1k-ca-certificate-check-bypass-fix.patch
@@ -1,0 +1,89 @@
+From 4cef0617eb7ff0a9970da1be032a07067cfa348e Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Mon, 22 Mar 2021 08:51:52 +0000
+Subject: [PATCH] check_chain_extensions: Do not override error return value by
+ check_curve
+
+The X509_V_FLAG_X509_STRICT flag enables additional security checks of the
+certificates present in a certificate chain. It is not set by default.
+
+Starting from OpenSSL version 1.1.1h a check to disallow certificates with
+explicitly encoded elliptic curve parameters in the chain was added to the
+strict checks.
+
+An error in the implementation of this check meant that the result of a
+previous check to confirm that certificates in the chain are valid CA
+certificates was overwritten. This effectively bypasses the check
+that non-CA certificates must not be able to issue other certificates.
+
+If a "purpose" has been configured then a subsequent check that the
+certificate is consistent with that purpose also checks that it is a
+valid CA. Therefore where a purpose is set the certificate chain will
+still be rejected even when the strict flag has been used. A purpose is
+set by default in libssl client and server certificate verification
+routines, but it can be overriden by an application.
+
+Affected applications explicitly set the X509_V_FLAG_X509_STRICT
+verification flag and either do not set a purpose for the certificate
+verification or, in the case of TLS client or server applications,
+override the default purpose to make it not set.
+
+CVE-2021-3450
+---
+ crypto/x509/x509_vfy.c   |  9 ++++++---
+ test/verify_extra_test.c | 16 ++++++++++++++--
+ 2 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 0c71b2e8b4..5f74dfa7fa 100644
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -524,13 +524,16 @@ static int check_chain_extensions(X509_STORE_CTX *ctx)
+                 ret = 1;
+             break;
+         }
+-        if ((ctx->param->flags & X509_V_FLAG_X509_STRICT) && num > 1) {
++        if (ret > 0
++            && (ctx->param->flags & X509_V_FLAG_X509_STRICT) && num > 1) {
+             /* Check for presence of explicit elliptic curve parameters */
+             ret = check_curve(x);
+-            if (ret < 0)
++            if (ret < 0) {
+                 ctx->error = X509_V_ERR_UNSPECIFIED;
+-            else if (ret == 0)
++                ret = 0;
++            } else if (ret == 0) {
+                 ctx->error = X509_V_ERR_EC_KEY_EXPLICIT_PARAMS;
++            }
+         }
+         if ((x->ex_flags & EXFLAG_CA) == 0
+             && x->ex_pathlen != -1
+diff --git a/test/verify_extra_test.c b/test/verify_extra_test.c
+index 010403e74a..b9959e0c66 100644
+--- a/test/verify_extra_test.c
++++ b/test/verify_extra_test.c
+@@ -140,10 +140,22 @@ static int test_alt_chains_cert_forgery(void)
+ 
+     i = X509_verify_cert(sctx);
+ 
+-    if (i == 0 && X509_STORE_CTX_get_error(sctx) == X509_V_ERR_INVALID_CA) {
++    if (i != 0 || X509_STORE_CTX_get_error(sctx) != X509_V_ERR_INVALID_CA)
++        goto err;
++
++    /* repeat with X509_V_FLAG_X509_STRICT */
++    X509_STORE_CTX_cleanup(sctx);
++    X509_STORE_set_flags(store, X509_V_FLAG_X509_STRICT);
++
++    if (!X509_STORE_CTX_init(sctx, store, x, untrusted))
++        goto err;
++
++    i = X509_verify_cert(sctx);
++
++    if (i == 0 && X509_STORE_CTX_get_error(sctx) == X509_V_ERR_INVALID_CA)
+         /* This is the result we were expecting: Test passed */
+         ret = 1;
+-    }
++
+  err:
+     X509_STORE_CTX_free(sctx);
+     X509_free(x);

--- a/dev-libs/openssl/files/openssl-1.1.1k-release-changes.patch
+++ b/dev-libs/openssl/files/openssl-1.1.1k-release-changes.patch
@@ -1,0 +1,596 @@
+From 97149c8219189c1bb61d36bfcd511956caeb4771 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 16 Feb 2021 15:24:11 +0000
+Subject: [PATCH 01/17] Prepare for 1.1.1k-dev
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+---
+ CHANGES                    | 4 ++++
+ NEWS                       | 4 ++++
+ README                     | 2 +-
+ include/openssl/opensslv.h | 4 ++--
+ 4 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/CHANGES b/CHANGES
+index 1ab64b35c9a4..8c2b701311db 100644
+--- a/CHANGES
++++ b/CHANGES
+@@ -7,6 +7,10 @@
+  https://github.com/openssl/openssl/commits/ and pick the appropriate
+  release branch.
+ 
++ Changes between 1.1.1j and 1.1.1k [xx XXX xxxx]
++
++  *)
++
+  Changes between 1.1.1i and 1.1.1j [16 Feb 2021]
+ 
+   *) Fixed the X509_issuer_and_serial_hash() function. It attempts to
+diff --git a/NEWS b/NEWS
+index 3cce52506645..7e1cdf94e047 100644
+--- a/NEWS
++++ b/NEWS
+@@ -5,6 +5,10 @@
+   This file gives a brief overview of the major changes between each OpenSSL
+   release. For more details please read the CHANGES file.
+ 
++  Major changes between OpenSSL 1.1.1j and OpenSSL 1.1.1k [under development]
++
++      o
++
+   Major changes between OpenSSL 1.1.1i and OpenSSL 1.1.1j [16 Feb 2021]
+ 
+       o Fixed a NULL pointer deref in the X509_issuer_and_serial_hash()
+diff --git a/README b/README
+index da5629f92c81..98ad8a356aa7 100644
+--- a/README
++++ b/README
+@@ -1,5 +1,5 @@
+ 
+- OpenSSL 1.1.1j 16 Feb 2021
++ OpenSSL 1.1.1k-dev
+ 
+  Copyright (c) 1998-2020 The OpenSSL Project
+  Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
+diff --git a/include/openssl/opensslv.h b/include/openssl/opensslv.h
+index cd5c23217a51..48c54fe673f1 100644
+--- a/include/openssl/opensslv.h
++++ b/include/openssl/opensslv.h
+@@ -39,8 +39,8 @@ extern "C" {
+  * (Prior to 0.9.5a beta1, a different scheme was used: MMNNFFRBB for
+  *  major minor fix final patch/beta)
+  */
+-# define OPENSSL_VERSION_NUMBER  0x101010afL
+-# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1j  16 Feb 2021"
++# define OPENSSL_VERSION_NUMBER  0x101010b0L
++# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1k-dev  xx XXX xxxx"
+ 
+ /*-
+  * The macros below are to be used for shared library (.so, .dll, ...)
+
+From 01cf4f868e08f82daa16d049fa7d241d8089c8d8 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Tue, 16 Feb 2021 20:02:24 +0100
+Subject: [PATCH 02/17] TEST: Add missing initialization
+
+Compiler complained.
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14204)
+
+(cherry picked from commit 55e9d8cfffc1a40b0ab72e014ff62d5ef2a0ed63)
+---
+ test/rsa_test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/rsa_test.c b/test/rsa_test.c
+index 11e373cceb1b..bdbab75f8f4e 100644
+--- a/test/rsa_test.c
++++ b/test/rsa_test.c
+@@ -304,7 +304,7 @@ static int test_rsa_sslv23(int idx)
+ static int test_rsa_oaep(int idx)
+ {
+     int ret = 0;
+-    RSA *key;
++    RSA *key = NULL;
+     unsigned char ptext[256];
+     unsigned char ctext[256];
+     static unsigned char ptext_ex[] = "\x54\x85\x9b\x34\x2c\x49\xea\x2a";
+
+From b6de54b2c1062f15819174784d9bd53c85c432d3 Mon Sep 17 00:00:00 2001
+From: John Baldwin <jhb@FreeBSD.org>
+Date: Fri, 20 Nov 2020 17:07:35 -0800
+Subject: [PATCH 03/17] Use CRIOGET to fetch a crypto descriptor when present.
+
+FreeBSD's current /dev/crypto implementation requires that consumers
+clone a separate file descriptor via the CRIOGET ioctl that can then
+be used with other ioctls such as CIOCGSESSION.
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Ben Kaduk <kaduk@mit.edu>
+
+(cherry picked from commit b39c215decf6e68c28cb64dcfaf5ae5a7e8d35b4)
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/13853)
+---
+ crypto/engine/eng_devcrypto.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/engine/eng_devcrypto.c b/crypto/engine/eng_devcrypto.c
+index 49e9ce1af33b..f03c01718132 100644
+--- a/crypto/engine/eng_devcrypto.c
++++ b/crypto/engine/eng_devcrypto.c
+@@ -758,8 +758,9 @@ static int devcrypto_unload(ENGINE *e)
+ void engine_load_devcrypto_int()
+ {
+     ENGINE *e = NULL;
++    int fd;
+ 
+-    if ((cfd = open("/dev/crypto", O_RDWR, 0)) < 0) {
++    if ((fd = open("/dev/crypto", O_RDWR, 0)) < 0) {
+ #ifndef ENGINE_DEVCRYPTO_DEBUG
+         if (errno != ENOENT)
+ #endif
+@@ -767,6 +768,16 @@ void engine_load_devcrypto_int()
+         return;
+     }
+ 
++#ifdef CRIOGET
++    if (ioctl(fd, CRIOGET, &cfd) < 0) {
++        fprintf(stderr, "Could not create crypto fd: %s\n", strerror(errno));
++        cfd = -1;
++        return;
++    }
++#else
++    cfd = fd;
++#endif
++
+     if ((e = ENGINE_new()) == NULL
+         || !ENGINE_set_destroy_function(e, devcrypto_unload)) {
+         ENGINE_free(e);
+
+From a12c6442f24a32867c971b6feb5db61d01b02c1f Mon Sep 17 00:00:00 2001
+From: John Baldwin <jhb@FreeBSD.org>
+Date: Thu, 7 Jan 2021 14:09:41 -0800
+Subject: [PATCH 04/17] Close /dev/crypto file descriptor after CRIOGET
+ ioctl().
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Ben Kaduk <kaduk@mit.edu>
+
+(cherry picked from commit 3ddf44ea5a2c1c8c55f4f4072a611791c79d4e7c)
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/13853)
+---
+ crypto/engine/eng_devcrypto.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/crypto/engine/eng_devcrypto.c b/crypto/engine/eng_devcrypto.c
+index f03c01718132..997271e15055 100644
+--- a/crypto/engine/eng_devcrypto.c
++++ b/crypto/engine/eng_devcrypto.c
+@@ -771,9 +771,11 @@ void engine_load_devcrypto_int()
+ #ifdef CRIOGET
+     if (ioctl(fd, CRIOGET, &cfd) < 0) {
+         fprintf(stderr, "Could not create crypto fd: %s\n", strerror(errno));
++        close(fd);
+         cfd = -1;
+         return;
+     }
++    close(fd);
+ #else
+     cfd = fd;
+ #endif
+
+From 8df5cc3339d10f91ccb395650a83c031c2795742 Mon Sep 17 00:00:00 2001
+From: Zhang Jinde <zjd5536@163.com>
+Date: Thu, 24 Sep 2020 14:48:28 +0800
+Subject: [PATCH 05/17] CRYPTO_gcm128_decrypt: fix mac or tag calculation
+
+The incorrect code is in #ifdef branch that is normally
+not compiled in.
+
+Signed-off-by: Zhang Jinde <zjd5536@163.com>
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/12968)
+
+(cherry picked from commit 1d724b5e82ba36fb50fd24db3cd664da570daf84)
+---
+ crypto/modes/gcm128.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/modes/gcm128.c b/crypto/modes/gcm128.c
+index 0c0bf3cda5b5..4b29ead08c2b 100644
+--- a/crypto/modes/gcm128.c
++++ b/crypto/modes/gcm128.c
+@@ -1385,8 +1385,8 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
+                 else
+                     ctx->Yi.d[3] = ctr;
+                 for (i = 0; i < 16 / sizeof(size_t); ++i) {
+-                    size_t c = in[i];
+-                    out[i] = c ^ ctx->EKi.t[i];
++                    size_t c = in_t[i];
++                    out_t[i] = c ^ ctx->EKi.t[i];
+                     ctx->Xi.t[i] ^= c;
+                 }
+                 GCM_MUL(ctx);
+
+From 1102187a71f6aa8f72daf46c5d543c261b90c83b Mon Sep 17 00:00:00 2001
+From: jwalch <jeremy.walch@gmail.com>
+Date: Fri, 19 Feb 2021 13:02:27 -0500
+Subject: [PATCH 06/17] Fix an integer overflow in o_time.c
+
+If input offset_sec is sufficiently large (> INT32_MAX * SECS_PER_DAY, which is possible for a long on 64-bit platforms), then the first assignment contains an overflow.
+
+I think leaving offset_hms as an int is still safe.
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14252)
+
+(cherry picked from commit 75de54363506e2b2480fc6baf0cd45b1f7fc8816)
+---
+ crypto/o_time.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/o_time.c b/crypto/o_time.c
+index 3502edda6238..6aafd67c46b2 100644
+--- a/crypto/o_time.c
++++ b/crypto/o_time.c
+@@ -133,8 +133,8 @@ int OPENSSL_gmtime_diff(int *pday, int *psec,
+ static int julian_adj(const struct tm *tm, int off_day, long offset_sec,
+                       long *pday, int *psec)
+ {
+-    int offset_hms, offset_day;
+-    long time_jd;
++    int offset_hms;
++    long offset_day, time_jd;
+     int time_year, time_month, time_day;
+     /* split offset into days and day seconds */
+     offset_day = offset_sec / SECS_PER_DAY;
+
+From 3a6e6b1f94ae41e2fd73483464c9c80ddcf30d17 Mon Sep 17 00:00:00 2001
+From: Mark <mark@asx.hu>
+Date: Wed, 24 Feb 2021 14:14:08 +0100
+Subject: [PATCH 07/17] Fix filename escaping in c_rehash
+
+CLA: trivial
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14301)
+
+(cherry picked from commit 2d968951227acd422f0e712035de3216d47fc980)
+---
+ tools/c_rehash.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/c_rehash.in b/tools/c_rehash.in
+index 421fd892086f..d97cab0ed5ec 100644
+--- a/tools/c_rehash.in
++++ b/tools/c_rehash.in
+@@ -161,7 +161,7 @@ sub check_file {
+ 
+ sub link_hash_cert {
+ 		my $fname = $_[0];
+-		$fname =~ s/'/'\\''/g;
++		$fname =~ s/\"/\\\"/g;
+ 		my ($hash, $fprint) = `"$openssl" x509 $x509hash -fingerprint -noout -in "$fname"`;
+ 		chomp $hash;
+ 		chomp $fprint;
+
+From a88ea7dfdfba2c34bd575076f12f06d80dd2c0c2 Mon Sep 17 00:00:00 2001
+From: Benjamin Kaduk <bkaduk@akamai.com>
+Date: Wed, 24 Feb 2021 13:38:25 -0800
+Subject: [PATCH 08/17] Check ASN1_item_ndef_i2d() return value.
+
+Return an error instead of trying to malloc a negative number.
+The other usage in this file already had a similar check, and the caller
+should have put an entry on the error stack already.
+
+Note that we only check the initial calls to obtain the encoded length,
+and assume that the follow-up call to actually encode to the allocated
+storage will succeed if the first one did.
+
+Fixes: #14177
+
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+(Merged from https://github.com/openssl/openssl/pull/14308)
+
+(cherry picked from commit 90b4247cc5dca58cee9da5f6975bb38fd200100a)
+---
+ crypto/asn1/bio_ndef.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/crypto/asn1/bio_ndef.c b/crypto/asn1/bio_ndef.c
+index 6222c99074de..564226271947 100644
+--- a/crypto/asn1/bio_ndef.c
++++ b/crypto/asn1/bio_ndef.c
+@@ -113,6 +113,8 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
+     ndef_aux = *(NDEF_SUPPORT **)parg;
+ 
+     derlen = ASN1_item_ndef_i2d(ndef_aux->val, NULL, ndef_aux->it);
++    if (derlen < 0)
++        return 0;
+     if ((p = OPENSSL_malloc(derlen)) == NULL) {
+         ASN1err(ASN1_F_NDEF_PREFIX, ERR_R_MALLOC_FAILURE);
+         return 0;
+
+From 01b9e18fb20ae158a056223fc62772887040d85f Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Tue, 2 Mar 2021 13:42:39 +0200
+Subject: [PATCH 09/17] [1.1.1] Fix `make update` for out-of-tree builds
+
+Fixes #11940
+
+Reviewed-by: Nicola Tuveri <nic.tuv@gmail.com>
+(Merged from https://github.com/openssl/openssl/pull/14388)
+---
+ Configurations/unix-Makefile.tmpl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 3a24d551359b..41648c952667 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -917,8 +917,8 @@ errors:
+           done )
+ 
+ ordinals:
+-	( b=`pwd`; cd $(SRCDIR); $(PERL) -I$$b util/mkdef.pl crypto update )
+-	( b=`pwd`; cd $(SRCDIR); $(PERL) -I$$b util/mkdef.pl ssl update )
++	$(PERL) $(SRCDIR)/util/mkdef.pl crypto update
++	$(PERL) $(SRCDIR)/util/mkdef.pl ssl update
+ 
+ test_ordinals:
+ 	( cd test; \
+
+From 081a7061f3da07318c4b0f5de67b82285630bf6b Mon Sep 17 00:00:00 2001
+From: panda <daniel.phan36@gmail.com>
+Date: Mon, 8 Mar 2021 13:12:42 -0800
+Subject: [PATCH 10/17] Check SSL_set1_chain error in set_cert_cb
+
+CLA: trivial
+
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14469)
+
+(cherry picked from commit 1aa7ecd0d3f6d9c3739cf2e2d87673a3be03b352)
+---
+ apps/s_cb.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/apps/s_cb.c b/apps/s_cb.c
+index 6406ddfb9e1b..7241df4978fd 100644
+--- a/apps/s_cb.c
++++ b/apps/s_cb.c
+@@ -934,7 +934,8 @@ static int set_cert_cb(SSL *ssl, void *arg)
+                 if (!SSL_build_cert_chain(ssl, 0))
+                     return 0;
+             } else if (exc->chain != NULL) {
+-                SSL_set1_chain(ssl, exc->chain);
++                if (!SSL_set1_chain(ssl, exc->chain))
++                    return 0;
+             }
+         }
+         exc = exc->prev;
+
+From 8129ac6ac4c0ca3a488c225cde580ede7dabe874 Mon Sep 17 00:00:00 2001
+From: Pauli <ppzgs1@gmail.com>
+Date: Wed, 17 Mar 2021 11:41:48 +1000
+Subject: [PATCH 11/17] modes: fix coverity 1449860: overlapping memory copy
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14584)
+
+(cherry picked from commit 145f12d12dc83c737676883c625c2a95d34251ed)
+---
+ crypto/modes/cbc128.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/modes/cbc128.c b/crypto/modes/cbc128.c
+index c85e37c6a546..4595b0f50226 100644
+--- a/crypto/modes/cbc128.c
++++ b/crypto/modes/cbc128.c
+@@ -69,7 +69,8 @@ void CRYPTO_cbc128_encrypt(const unsigned char *in, unsigned char *out,
+         in += 16;
+         out += 16;
+     }
+-    memcpy(ivec, iv, 16);
++    if (ivec != iv)
++        memcpy(ivec, iv, 16);
+ }
+ 
+ void CRYPTO_cbc128_decrypt(const unsigned char *in, unsigned char *out,
+
+From 81198bf323ea9deda907714170d329ca7d2ff01f Mon Sep 17 00:00:00 2001
+From: Pauli <ppzgs1@gmail.com>
+Date: Wed, 17 Mar 2021 11:40:13 +1000
+Subject: [PATCH 12/17] modes: fix coverity 1449851: overlapping memory copy
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14584)
+
+(cherry picked from commit b875e0e820b07420429ebb90724ed28686a98853)
+---
+ crypto/modes/cbc128.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/modes/cbc128.c b/crypto/modes/cbc128.c
+index 4595b0f50226..78949c1ed7ed 100644
+--- a/crypto/modes/cbc128.c
++++ b/crypto/modes/cbc128.c
+@@ -115,7 +115,8 @@ void CRYPTO_cbc128_decrypt(const unsigned char *in, unsigned char *out,
+                 out += 16;
+             }
+         }
+-        memcpy(ivec, iv, 16);
++        if (ivec != iv)
++            memcpy(ivec, iv, 16);
+     } else {
+         if (STRICT_ALIGNMENT &&
+             ((size_t)in | (size_t)out | (size_t)ivec) % sizeof(size_t) != 0) {
+
+From 1136fedc334b574eef6f551be158860fda4199f2 Mon Sep 17 00:00:00 2001
+From: Pauli <ppzgs1@gmail.com>
+Date: Wed, 17 Mar 2021 12:00:42 +1000
+Subject: [PATCH 13/17] ssl: fix coverity 1451515: out of bounds memory access
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14585)
+
+(cherry picked from commit 3de7f014a985637361bdee775f78209300c88aae)
+---
+ ssl/statem/statem_clnt.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ssl/statem/statem_clnt.c b/ssl/statem/statem_clnt.c
+index d84cc0460f4e..09fba3d8c0c7 100644
+--- a/ssl/statem/statem_clnt.c
++++ b/ssl/statem/statem_clnt.c
+@@ -2905,6 +2905,7 @@ static int tls_construct_cke_psk_preamble(SSL *s, WPACKET *pkt)
+     if (psklen > PSK_MAX_PSK_LEN) {
+         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
+                  SSL_F_TLS_CONSTRUCT_CKE_PSK_PREAMBLE, ERR_R_INTERNAL_ERROR);
++        psklen = PSK_MAX_PSK_LEN;   /* Avoid overrunning the array on cleanse */
+         goto err;
+     } else if (psklen == 0) {
+         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
+
+From f9398cc2b31858ddaaea3f5cfec2fce7f9b90347 Mon Sep 17 00:00:00 2001
+From: Pauli <ppzgs1@gmail.com>
+Date: Wed, 17 Mar 2021 12:23:52 +1000
+Subject: [PATCH 14/17] apps: fix coverity 966560: division by zero
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14586)
+
+(cherry picked from commit 7e7e034a10842dad3866c9447481b8527024bf44)
+---
+ apps/s_time.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/apps/s_time.c b/apps/s_time.c
+index 628e65b26e19..eabf3c1a7979 100644
+--- a/apps/s_time.c
++++ b/apps/s_time.c
+@@ -263,7 +263,8 @@ int s_time_main(int argc, char **argv)
+          nConn, totalTime, ((double)nConn / totalTime), bytes_read);
+     printf
+         ("%d connections in %ld real seconds, %ld bytes read per connection\n",
+-         nConn, (long)time(NULL) - finishtime + maxtime, bytes_read / nConn);
++         nConn, (long)time(NULL) - finishtime + maxtime,
++         nConn > 0 ? bytes_read / nConn : 0l);
+ 
+     /*
+      * Now loop and time connections using the same session id over and over
+
+From b402f00ee26157ad4e7e6e52f3a736743e3de46f Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Thu, 18 Mar 2021 10:22:51 +0000
+Subject: [PATCH 15/17] Add a missing RUN_ONCE in rand_lib.c
+
+Some of the callbacks in rand_lib.c were being invoked without the
+RUN_ONCE for that file being called. We add it during rand_pool_new
+which should cover all cases.
+
+Fixes #7870
+Fixes #11144
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14603)
+---
+ crypto/rand/rand_lib.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/rand/rand_lib.c b/crypto/rand/rand_lib.c
+index ba3a29e58468..46e83d0741fe 100644
+--- a/crypto/rand/rand_lib.c
++++ b/crypto/rand/rand_lib.c
+@@ -432,9 +432,13 @@ int RAND_poll(void)
+ RAND_POOL *rand_pool_new(int entropy_requested, int secure,
+                          size_t min_len, size_t max_len)
+ {
+-    RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
++    RAND_POOL *pool;
+     size_t min_alloc_size = RAND_POOL_MIN_ALLOCATION(secure);
+ 
++    if (!RUN_ONCE(&rand_init, do_rand_init))
++        return NULL;
++
++    pool = OPENSSL_zalloc(sizeof(*pool));
+     if (pool == NULL) {
+         RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
+         return NULL;
+
+From ffefffa000437da5703dd8a173386623304b055d Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Sat, 20 Mar 2021 09:09:40 +0100
+Subject: [PATCH 16/17] ASN1: Reset the content dump flag after dumping
+
+When encountering a badly coded item, the DER printer (ASN1_print_dump())
+sets a flag to ensure that an additional hex dump of the offending content
+is printed as part of the output.  Unfortunately, this flag is never reset,
+which means that all following items are printed with the extra hex dump,
+whether they are faulty or not.
+
+Resetting the flag after hex dumping ensures that only the faulty contents
+are printed with the additional hex dump.
+
+Fixes #14626
+
+Reviewed-by: Tim Hudson <tjh@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14627)
+
+(cherry picked from commit 6e34a1048ce4871371eac224b995c3b4338f6166)
+---
+ crypto/asn1/asn1_par.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/crypto/asn1/asn1_par.c b/crypto/asn1/asn1_par.c
+index 3f10c7cb94c5..d45f810bce03 100644
+--- a/crypto/asn1/asn1_par.c
++++ b/crypto/asn1/asn1_par.c
+@@ -325,6 +325,7 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
+                 }
+                 if (BIO_puts(bp, "]") <= 0)
+                     goto end;
++                dump_cont = 0;
+             }
+ 
+             if (!nl) {
+
+From cfd74383d9b06f85cb1e166180346115a3f9a452 Mon Sep 17 00:00:00 2001
+From: Chenglong Zhang <auvkone@gmail.com>
+Date: Mon, 22 Mar 2021 15:29:28 +0800
+Subject: [PATCH 17/17] Fix missing INVALID_EXTENSION
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Ben Kaduk <kaduk@mit.edu>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/14639)
+---
+ ssl/statem/extensions.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/ssl/statem/extensions.c b/ssl/statem/extensions.c
+index 9f51a6eb28d9..b055935d697b 100644
+--- a/ssl/statem/extensions.c
++++ b/ssl/statem/extensions.c
+@@ -336,6 +336,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
+         tls_construct_stoc_key_share, tls_construct_ctos_key_share,
+         final_key_share
+     },
++#else
++    INVALID_EXTENSION,
+ #endif
+     {
+         /* Must be after key_share */

--- a/dev-libs/openssl/files/openssl-1.1.1k-teach-tlsproxy-encrypt-etm-records.patch
+++ b/dev-libs/openssl/files/openssl-1.1.1k-teach-tlsproxy-encrypt-etm-records.patch
@@ -1,0 +1,463 @@
+From 45793142f5a52974c3486dd29281d929f69110fb Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Thu, 18 Mar 2021 15:25:42 +0000
+Subject: [PATCH 1/4] Teach TLSProxy how to encrypt <= TLSv1.2 ETM records
+
+Previously TLSProxy only knew how to "repack" messages for TLSv1.3.
+Most of the handshake in <= TLSv1.2 is unencrypted so this hasn't been
+too much of restriction. However we now want to modify reneg handshakes
+which are encrypted so we need to add that capability.
+---
+ util/perl/TLSProxy/Message.pm | 37 ++++++++++++++++++++++++++++-------
+ 1 file changed, 30 insertions(+), 7 deletions(-)
+
+diff --git a/util/perl/TLSProxy/Message.pm b/util/perl/TLSProxy/Message.pm
+index 10b6156074..3d0266e48f 100644
+--- a/util/perl/TLSProxy/Message.pm
++++ b/util/perl/TLSProxy/Message.pm
+@@ -448,7 +448,7 @@ sub ciphersuite
+ }
+ 
+ #Update all the underlying records with the modified data from this message
+-#Note: Only supports re-encrypting for TLSv1.3
++#Note: Only supports TLSv1.3 and ETM encryption
+ sub repack
+ {
+     my $self = shift;
+@@ -490,15 +490,38 @@ sub repack
+         # (If a length override is ever needed to construct invalid packets,
+         #  use an explicit override field instead.)
+         $rec->decrypt_len(length($rec->decrypt_data));
+-        $rec->len($rec->len + length($msgdata) - $old_length);
+-        # Only support re-encryption for TLSv1.3.
+-        if (TLSProxy::Proxy->is_tls13() && $rec->encrypted()) {
+-            #Add content type (1 byte) and 16 tag bytes
+-            $rec->data($rec->decrypt_data
+-                .pack("C", TLSProxy::Record::RT_HANDSHAKE).("\0"x16));
++        # Only support re-encryption for TLSv1.3 and ETM.
++        if ($rec->encrypted()) {
++            if (TLSProxy::Proxy->is_tls13()) {
++                #Add content type (1 byte) and 16 tag bytes
++                $rec->data($rec->decrypt_data
++                    .pack("C", TLSProxy::Record::RT_HANDSHAKE).("\0"x16));
++            } elsif ($rec->etm()) {
++                my $data = $rec->decrypt_data;
++                #Add padding
++                my $padval = length($data) % 16;
++                $padval = 15 - $padval;
++                for (0..$padval) {
++                    $data .= pack("C", $padval);
++                }
++
++                #Add MAC. Assumed to be 20 bytes
++                foreach my $macval (0..19) {
++                    $data .= pack("C", $macval);
++                }
++
++                if ($rec->version() >= TLSProxy::Record::VERS_TLS_1_1) {
++                    #Explicit IV
++                    $data = ("\0"x16).$data;
++                }
++                $rec->data($data);
++            } else {
++                die "Unsupported encryption: No ETM";
++            }
+         } else {
+             $rec->data($rec->decrypt_data);
+         }
++        $rec->len(length($rec->data));
+ 
+         #Update the fragment len in case we changed it above
+         ${$self->message_frag_lens}[0] = length($msgdata)
+
+From 0cb44054466536a326019ba2ac2f57fe9b894909 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Thu, 18 Mar 2021 15:29:04 +0000
+Subject: [PATCH 2/4] Add a test for CVE-2021-3449
+
+We perform a reneg handshake, where the second ClientHello drops the
+sig_algs extension. It must also contain cert_sig_algs for the test to
+work.
+---
+ test/recipes/70-test_renegotiation.t | 36 +++++++++++++++++++++++++++-
+ 1 file changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/test/recipes/70-test_renegotiation.t b/test/recipes/70-test_renegotiation.t
+index 734f1cd21e..89cab85aa1 100644
+--- a/test/recipes/70-test_renegotiation.t
++++ b/test/recipes/70-test_renegotiation.t
+@@ -38,7 +38,7 @@ my $proxy = TLSProxy::Proxy->new(
+ $proxy->clientflags("-no_tls1_3");
+ $proxy->reneg(1);
+ $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+-plan tests => 3;
++plan tests => 4;
+ ok(TLSProxy::Message->success(), "Basic renegotiation");
+ 
+ #Test 2: Client does not send the Reneg SCSV. Reneg should fail
+@@ -77,6 +77,20 @@ SKIP: {
+        "Check ClientHello version is the same");
+ }
+ 
++SKIP: {
++    skip "TLSv1.2 disabled", 1
++        if disabled("tls1_2");
++
++    #Test 4: Test for CVE-2021-3449. client_sig_algs instead of sig_algs in
++    #        resumption ClientHello
++    $proxy->clear();
++    $proxy->filter(\&sigalgs_filter);
++    $proxy->clientflags("-tls1_2");
++    $proxy->reneg(1);
++    $proxy->start();
++    ok(TLSProxy::Message->fail(), "client_sig_algs instead of sig_algs");
++}
++
+ sub reneg_filter
+ {
+     my $proxy = shift;
+@@ -96,3 +110,23 @@ sub reneg_filter
+         }
+     }
+ }
++
++sub sigalgs_filter
++{
++    my $proxy = shift;
++    my $cnt = 0;
++
++    # We're only interested in the second ClientHello message
++    foreach my $message (@{$proxy->message_list}) {
++        if ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO) {
++            next if ($cnt++ == 0);
++
++            my $sigs = pack "C10", 0x00, 0x08,
++                            # rsa_pkcs_sha{256,384,512,1}
++                            0x04, 0x01,  0x05, 0x01,  0x06, 0x01,  0x02, 0x01;
++            $message->set_extension(TLSProxy::Message::EXT_SIG_ALGS_CERT, $sigs);
++            $message->delete_extension(TLSProxy::Message::EXT_SIG_ALGS);
++            $message->repack();
++        }
++    }
++}
+
+From c911f9f10651d5bb502a40884680ad81b06a4ff9 Mon Sep 17 00:00:00 2001
+From: Peter Kaestle <peter.kaestle@nokia.com>
+Date: Mon, 15 Mar 2021 13:19:56 +0100
+Subject: [PATCH 3/4] ssl sigalg extension: fix NULL pointer dereference
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As the variable peer_sigalgslen is not cleared on ssl rehandshake, it's
+possible to crash an openssl tls secured server remotely by sending a
+manipulated hello message in a rehandshake.
+
+On such a manipulated rehandshake, tls1_set_shared_sigalgs() calls
+tls12_shared_sigalgs() with the peer_sigalgslen of the previous
+handshake, while the peer_sigalgs has been freed.
+As a result tls12_shared_sigalgs() walks over the available
+peer_sigalgs and tries to access data of a NULL pointer.
+
+This issue was introduced by c589c34e61 (Add support for the TLS 1.3
+signature_algorithms_cert extension, 2018-01-11).
+
+Signed-off-by: Peter Kästle <peter.kaestle@nokia.com>
+Signed-off-by: Samuel Sapalski <samuel.sapalski@nokia.com>
+
+CVE-2021-3449
+
+CLA: trivial
+---
+ ssl/statem/extensions.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ssl/statem/extensions.c b/ssl/statem/extensions.c
+index 9f51a6eb28..c77ed8c1e5 100644
+--- a/ssl/statem/extensions.c
++++ b/ssl/statem/extensions.c
+@@ -1137,6 +1137,7 @@ static int init_sig_algs(SSL *s, unsigned int context)
+     /* Clear any signature algorithms extension received */
+     OPENSSL_free(s->s3->tmp.peer_sigalgs);
+     s->s3->tmp.peer_sigalgs = NULL;
++    s->s3->tmp.peer_sigalgslen = 0;
+ 
+     return 1;
+ }
+
+From 3259aace3715440b49c20dc318f10363f03590ea Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Thu, 18 Mar 2021 16:52:10 +0000
+Subject: [PATCH 4/4] Ensure buffer/length pairs are always in sync
+
+Following on from CVE-2021-3449 which was caused by a non-zero length
+associated with a NULL buffer, other buffer/length pairs are updated to
+ensure that they too are always in sync.
+---
+ ssl/s3_lib.c                 |  5 ++++-
+ ssl/ssl_lib.c                | 14 +++++++++++---
+ ssl/statem/extensions.c      |  1 +
+ ssl/statem/extensions_clnt.c | 14 ++++++++++++--
+ ssl/statem/statem_clnt.c     |  7 ++++++-
+ ssl/statem/statem_srvr.c     | 17 ++++++++++++++---
+ 6 files changed, 48 insertions(+), 10 deletions(-)
+
+diff --git a/ssl/s3_lib.c b/ssl/s3_lib.c
+index 4511b52c9a..80e0865770 100644
+--- a/ssl/s3_lib.c
++++ b/ssl/s3_lib.c
+@@ -4629,6 +4629,7 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
+ 
+         OPENSSL_clear_free(s->s3->tmp.psk, psklen);
+         s->s3->tmp.psk = NULL;
++        s->s3->tmp.psklen = 0;
+         if (!s->method->ssl3_enc->generate_master_secret(s,
+                     s->session->master_key, pskpms, pskpmslen,
+                     &s->session->master_key_length)) {
+@@ -4658,8 +4659,10 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
+         else
+             OPENSSL_cleanse(pms, pmslen);
+     }
+-    if (s->server == 0)
++    if (s->server == 0) {
+         s->s3->tmp.pms = NULL;
++        s->s3->tmp.pmslen = 0;
++    }
+     return ret;
+ }
+ 
+diff --git a/ssl/ssl_lib.c b/ssl/ssl_lib.c
+index 98057921f8..fd1acf1a32 100644
+--- a/ssl/ssl_lib.c
++++ b/ssl/ssl_lib.c
+@@ -779,8 +779,10 @@ SSL *SSL_new(SSL_CTX *ctx)
+         s->ext.ecpointformats =
+             OPENSSL_memdup(ctx->ext.ecpointformats,
+                            ctx->ext.ecpointformats_len);
+-        if (!s->ext.ecpointformats)
++        if (!s->ext.ecpointformats) {
++            s->ext.ecpointformats_len = 0;
+             goto err;
++        }
+         s->ext.ecpointformats_len =
+             ctx->ext.ecpointformats_len;
+     }
+@@ -789,8 +791,10 @@ SSL *SSL_new(SSL_CTX *ctx)
+             OPENSSL_memdup(ctx->ext.supportedgroups,
+                            ctx->ext.supportedgroups_len
+                                 * sizeof(*ctx->ext.supportedgroups));
+-        if (!s->ext.supportedgroups)
++        if (!s->ext.supportedgroups) {
++            s->ext.supportedgroups_len = 0;
+             goto err;
++        }
+         s->ext.supportedgroups_len = ctx->ext.supportedgroups_len;
+     }
+ #endif
+@@ -800,8 +804,10 @@ SSL *SSL_new(SSL_CTX *ctx)
+ 
+     if (s->ctx->ext.alpn) {
+         s->ext.alpn = OPENSSL_malloc(s->ctx->ext.alpn_len);
+-        if (s->ext.alpn == NULL)
++        if (s->ext.alpn == NULL) {
++            s->ext.alpn_len = 0;
+             goto err;
++        }
+         memcpy(s->ext.alpn, s->ctx->ext.alpn, s->ctx->ext.alpn_len);
+         s->ext.alpn_len = s->ctx->ext.alpn_len;
+     }
+@@ -2834,6 +2840,7 @@ int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
+     OPENSSL_free(ctx->ext.alpn);
+     ctx->ext.alpn = OPENSSL_memdup(protos, protos_len);
+     if (ctx->ext.alpn == NULL) {
++        ctx->ext.alpn_len = 0;
+         SSLerr(SSL_F_SSL_CTX_SET_ALPN_PROTOS, ERR_R_MALLOC_FAILURE);
+         return 1;
+     }
+@@ -2853,6 +2860,7 @@ int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
+     OPENSSL_free(ssl->ext.alpn);
+     ssl->ext.alpn = OPENSSL_memdup(protos, protos_len);
+     if (ssl->ext.alpn == NULL) {
++        ssl->ext.alpn_len = 0;
+         SSLerr(SSL_F_SSL_SET_ALPN_PROTOS, ERR_R_MALLOC_FAILURE);
+         return 1;
+     }
+diff --git a/ssl/statem/extensions.c b/ssl/statem/extensions.c
+index c77ed8c1e5..a80f637b88 100644
+--- a/ssl/statem/extensions.c
++++ b/ssl/statem/extensions.c
+@@ -1147,6 +1147,7 @@ static int init_sig_algs_cert(SSL *s, unsigned int context)
+     /* Clear any signature algorithms extension received */
+     OPENSSL_free(s->s3->tmp.peer_cert_sigalgs);
+     s->s3->tmp.peer_cert_sigalgs = NULL;
++    s->s3->tmp.peer_cert_sigalgslen = 0;
+ 
+     return 1;
+ }
+diff --git a/ssl/statem/extensions_clnt.c b/ssl/statem/extensions_clnt.c
+index bcce0f1d95..00a902ac79 100644
+--- a/ssl/statem/extensions_clnt.c
++++ b/ssl/statem/extensions_clnt.c
+@@ -816,6 +816,7 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
+         OPENSSL_free(s->psksession_id);
+         s->psksession_id = OPENSSL_memdup(id, idlen);
+         if (s->psksession_id == NULL) {
++            s->psksession_id_len = 0;
+             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                      SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA, ERR_R_INTERNAL_ERROR);
+             return EXT_RETURN_FAIL;
+@@ -1375,6 +1376,7 @@ int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
+         OPENSSL_free(s->ext.peer_ecpointformats);
+         s->ext.peer_ecpointformats = OPENSSL_malloc(ecpointformats_len);
+         if (s->ext.peer_ecpointformats == NULL) {
++            s->ext.peer_ecpointformats_len = 0;
+             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                      SSL_F_TLS_PARSE_STOC_EC_PT_FORMATS, ERR_R_INTERNAL_ERROR);
+             return 0;
+@@ -1492,8 +1494,13 @@ int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
+         s->ext.scts_len = (uint16_t)size;
+         if (size > 0) {
+             s->ext.scts = OPENSSL_malloc(size);
+-            if (s->ext.scts == NULL
+-                    || !PACKET_copy_bytes(pkt, s->ext.scts, size)) {
++            if (s->ext.scts == NULL) {
++                s->ext.scts_len = 0;
++                SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_SCT,
++                         ERR_R_MALLOC_FAILURE);
++                return 0;
++            }
++            if (!PACKET_copy_bytes(pkt, s->ext.scts, size)) {
+                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_SCT,
+                          ERR_R_INTERNAL_ERROR);
+                 return 0;
+@@ -1592,6 +1599,7 @@ int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
+     OPENSSL_free(s->ext.npn);
+     s->ext.npn = OPENSSL_malloc(selected_len);
+     if (s->ext.npn == NULL) {
++        s->ext.npn_len = 0;
+         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_NPN,
+                  ERR_R_INTERNAL_ERROR);
+         return 0;
+@@ -1632,6 +1640,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
+     OPENSSL_free(s->s3->alpn_selected);
+     s->s3->alpn_selected = OPENSSL_malloc(len);
+     if (s->s3->alpn_selected == NULL) {
++        s->s3->alpn_selected_len = 0;
+         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_ALPN,
+                  ERR_R_INTERNAL_ERROR);
+         return 0;
+@@ -1663,6 +1672,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
+         s->session->ext.alpn_selected =
+             OPENSSL_memdup(s->s3->alpn_selected, s->s3->alpn_selected_len);
+         if (s->session->ext.alpn_selected == NULL) {
++            s->session->ext.alpn_selected_len = 0;
+             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_ALPN,
+                      ERR_R_INTERNAL_ERROR);
+             return 0;
+diff --git a/ssl/statem/statem_clnt.c b/ssl/statem/statem_clnt.c
+index 09fba3d8c0..de58f1a4b7 100644
+--- a/ssl/statem/statem_clnt.c
++++ b/ssl/statem/statem_clnt.c
+@@ -2462,6 +2462,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
+         s->s3->tmp.ctype_len = 0;
+         OPENSSL_free(s->pha_context);
+         s->pha_context = NULL;
++        s->pha_context_len = 0;
+ 
+         if (!PACKET_get_length_prefixed_1(pkt, &reqctx) ||
+             !PACKET_memdup(&reqctx, &s->pha_context, &s->pha_context_len)) {
+@@ -2771,16 +2772,17 @@ int tls_process_cert_status_body(SSL *s, PACKET *pkt)
+     }
+     s->ext.ocsp.resp = OPENSSL_malloc(resplen);
+     if (s->ext.ocsp.resp == NULL) {
++        s->ext.ocsp.resp_len = 0;
+         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CERT_STATUS_BODY,
+                  ERR_R_MALLOC_FAILURE);
+         return 0;
+     }
++    s->ext.ocsp.resp_len = resplen;
+     if (!PACKET_copy_bytes(pkt, s->ext.ocsp.resp, resplen)) {
+         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PROCESS_CERT_STATUS_BODY,
+                  SSL_R_LENGTH_MISMATCH);
+         return 0;
+     }
+-    s->ext.ocsp.resp_len = resplen;
+ 
+     return 1;
+ }
+@@ -3351,9 +3353,11 @@ int tls_construct_client_key_exchange(SSL *s, WPACKET *pkt)
+  err:
+     OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
+     s->s3->tmp.pms = NULL;
++    s->s3->tmp.pmslen = 0;
+ #ifndef OPENSSL_NO_PSK
+     OPENSSL_clear_free(s->s3->tmp.psk, s->s3->tmp.psklen);
+     s->s3->tmp.psk = NULL;
++    s->s3->tmp.psklen = 0;
+ #endif
+     return 0;
+ }
+@@ -3428,6 +3432,7 @@ int tls_client_key_exchange_post_work(SSL *s)
+  err:
+     OPENSSL_clear_free(pms, pmslen);
+     s->s3->tmp.pms = NULL;
++    s->s3->tmp.pmslen = 0;
+     return 0;
+ }
+ 
+diff --git a/ssl/statem/statem_srvr.c b/ssl/statem/statem_srvr.c
+index cf45a40ce4..2ad44e2a64 100644
+--- a/ssl/statem/statem_srvr.c
++++ b/ssl/statem/statem_srvr.c
+@@ -2178,6 +2178,7 @@ int tls_handle_alpn(SSL *s)
+             OPENSSL_free(s->s3->alpn_selected);
+             s->s3->alpn_selected = OPENSSL_memdup(selected, selected_len);
+             if (s->s3->alpn_selected == NULL) {
++                s->s3->alpn_selected_len = 0;
+                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_HANDLE_ALPN,
+                          ERR_R_INTERNAL_ERROR);
+                 return 0;
+@@ -2853,9 +2854,16 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
+         if (s->post_handshake_auth == SSL_PHA_REQUEST_PENDING) {
+             OPENSSL_free(s->pha_context);
+             s->pha_context_len = 32;
+-            if ((s->pha_context = OPENSSL_malloc(s->pha_context_len)) == NULL
+-                    || RAND_bytes(s->pha_context, s->pha_context_len) <= 0
+-                    || !WPACKET_sub_memcpy_u8(pkt, s->pha_context, s->pha_context_len)) {
++            if ((s->pha_context = OPENSSL_malloc(s->pha_context_len)) == NULL) {
++                s->pha_context_len = 0;
++                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
++                         SSL_F_TLS_CONSTRUCT_CERTIFICATE_REQUEST,
++                         ERR_R_INTERNAL_ERROR);
++                return 0;
++            }
++            if (RAND_bytes(s->pha_context, s->pha_context_len) <= 0
++                    || !WPACKET_sub_memcpy_u8(pkt, s->pha_context,
++                                              s->pha_context_len)) {
+                 SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                          SSL_F_TLS_CONSTRUCT_CERTIFICATE_REQUEST,
+                          ERR_R_INTERNAL_ERROR);
+@@ -2969,6 +2977,7 @@ static int tls_process_cke_psk_preamble(SSL *s, PACKET *pkt)
+     OPENSSL_cleanse(psk, psklen);
+ 
+     if (s->s3->tmp.psk == NULL) {
++        s->s3->tmp.psklen = 0;
+         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                  SSL_F_TLS_PROCESS_CKE_PSK_PREAMBLE, ERR_R_MALLOC_FAILURE);
+         return 0;
+@@ -3508,6 +3517,7 @@ MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL *s, PACKET *pkt)
+ #ifndef OPENSSL_NO_PSK
+     OPENSSL_clear_free(s->s3->tmp.psk, s->s3->tmp.psklen);
+     s->s3->tmp.psk = NULL;
++    s->s3->tmp.psklen = 0;
+ #endif
+     return MSG_PROCESS_ERROR;
+ }
+@@ -4117,6 +4127,7 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
+             s->session->ext.alpn_selected =
+                 OPENSSL_memdup(s->s3->alpn_selected, s->s3->alpn_selected_len);
+             if (s->session->ext.alpn_selected == NULL) {
++                s->session->ext.alpn_selected_len = 0;
+                 SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                          SSL_F_TLS_CONSTRUCT_NEW_SESSION_TICKET,
+                          ERR_R_MALLOC_FAILURE);

--- a/dev-libs/openssl/openssl-1.1.1k.ebuild
+++ b/dev-libs/openssl/openssl-1.1.1k.ebuild
@@ -18,7 +18,7 @@ BINDIST_PATCH_SET="openssl-1.1.1i-bindist-1.0.tar.xz"
 
 DESCRIPTION="full-strength general purpose cryptography library (including SSL and TLS)"
 HOMEPAGE="https://www.openssl.org/"
-SRC_URI="mirror://openssl/source/${MY_P}.tar.gz
+SRC_URI="mirror://openssl/source/openssl-1.1.1j.tar.gz
 	bindist? (
 		mirror://gentoo/${BINDIST_PATCH_SET}
 		https://dev.gentoo.org/~whissi/dist/openssl/${BINDIST_PATCH_SET}
@@ -47,9 +47,12 @@ PDEPEND="app-misc/ca-certificates"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.1.0j-parallel_install_fix.patch #671602
+	"${FILESDIR}"/${PN}-1.1.1k-release-changes.patch
+	"${FILESDIR}"/${PN}-1.1.1k-ca-certificate-check-bypass-fix.patch
+	"${FILESDIR}"/${PN}-1.1.1k-teach-tlsproxy-encrypt-etm-records.patch
 )
 
-S="${WORKDIR}/${MY_P}"
+S="${WORKDIR}/openssl-1.1.1j"
 
 # force upgrade to prevent broken login, bug 696950
 RDEPEND+=" !<net-misc/openssh-8.0_p1-r3"

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -1,5 +1,5 @@
 # Overwrite outdated portage-stable mask
-=dev-libs/openssl-1.1.1j
+=dev-libs/openssl-1.1.1k
 
 # Overwrite portage-stable mask - this package was removed in
 # gentoo. We still need it, since sys-libs/libsemanage still requires


### PR DESCRIPTION
# dev-libs/openssl: Add the patch for openssl-1.1.1k release

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# How to use

```bash
emerge-amd64-usr openssl
```

# Testing done

Locally Tested and Jenkins build passed.

