### PR TITLE
profiles: force to use ssl USE flag for wget

### DIFF
--- a/profiles/coreos/arm64/package.use.force
+++ b/profiles/coreos/arm64/package.use.force
@@ -1,2 +1,7 @@
 sys-auth/polkit -introspection
 sys-apps/systemd -introspection
+
+# Matt Turner <mattst88@gentoo.org> (2020-03-28)
+# wget is the default FETCHCOMMAND, and most distfiles are distributed via
+# HTTPS. Bug #611072
+net-misc/wget ssl

--- a/profiles/coreos/base/package.use.force
+++ b/profiles/coreos/base/package.use.force
@@ -7,3 +7,8 @@ sys-libs/glibc crypt
 
 # Do not force this flag, we don't need XATTR_PAX
 sys-apps/portage -xattr
+
+# Matt Turner <mattst88@gentoo.org> (2020-03-28)
+# wget is the default FETCHCOMMAND, and most distfiles are distributed via
+# HTTPS. Bug #611072
+net-misc/wget ssl


### PR DESCRIPTION
This reverts commit f8dda51d546b466d9faf0c936b2ad5592ab1639e.

Recently we dropped `bindist` from `RESTRICT` in openssl, so it is now possible to turn on `ssl` for wget again.
The issue of openssl being blocked by `masked by: bindist in RESTRICT` etc. has now disappeared.

Fixes https://github.com/kinvolk/Flatcar/issues/149

## Testing done

CI passed https://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2352/cldsv/
