### PR TITLE
profiles: delete ccache completely

### DIFF
--- a/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
+++ b/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
@@ -18,7 +18,6 @@ RDEPEND="${RDEPEND}
 	app-admin/sudo
 	sys-apps/less
 	dev-embedded/u-boot-tools
-	dev-util/ccache
 	dev-util/crosutils
 	!arm64? ( sys-boot/syslinux )
 	sys-devel/crossdev

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -79,14 +79,6 @@ LINGUAS="en"
 PORTAGE_BZIP2_COMMAND="lbzip2"
 PORTAGE_BUNZIP2_COMMAND="lbunzip2"
 
-# Compression allows keeping a much more complete cache, otherwise the
-# kernel alone will eat 1.2GB instead of 455MB. Using /var/tmp/ccache
-# instead of ${ROOT}/var/tmp/ccache enables sharing results across
-# setup_board --force and between different boards of the same arch.
-CCACHE_COMPRESS=1
-CCACHE_COMPILERCHECK=content
-CCACHE_DIR="/var/tmp/ccache"
-
 # Always build binary packages, remove old build logs, avoid running as root.
 FEATURES="buildpkg clean-logs compressdebug parallel-install splitdebug
           userfetch userpriv usersandbox ipc-sandbox network-sandbox

--- a/profiles/coreos/targets/sdk/make.defaults
+++ b/profiles/coreos/targets/sdk/make.defaults
@@ -13,9 +13,6 @@ QEMU_SOFTMMU_TARGETS="x86_64 i386 aarch64"
 # For cross build support.
 QEMU_USER_TARGETS="aarch64"
 
-# Disable ccache in the SDK so it stops randomly breaking catalyst.
-FEATURES="-ccache"
-
 # add cros_host to bootstrapping USE flags so SDK / toolchains bootstrapping
 # will use vim's vimrc instead of baselayouts',
 BOOTSTRAP_USE="$BOOTSTRAP_USE cros_host"

--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -2,7 +2,6 @@ coreos-base/update_engine delta_generator
 
 dev-vcs/git pcre
 
-dev-util/catalyst ccache
 dev-lang/python sqlite
 
 dev-lang/rust rustfmt


### PR DESCRIPTION
As we do not use ccache at all, we should simply clean up ccache from all of the code, to shrink size of the SDK.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/161 .

## Testing done

CI passed: https://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2353/cldsv/