### PR TITLE
sys-kernel/bootengine: Enable iSCSI netroot devices on Flatcar

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="39ec7086703f9b4af3ea1a0681612325f65015ad" # flatcar-master
+	CROS_WORKON_COMMIT="b36e1943b35dac73b15c1105e5657b6459593b95" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This change pulls in the latest bootengine version, that enables ISCSI
support in dracut and avoids tearing down the network when using netroot

See https://github.com/kinvolk/bootengine/pull/22 for more information.

This was already tested and it worked fine, this is just the PR for pulling in the change to coreos-overlay.

