### PR TITLE
coreos-base/oem-gce: use systemd-nspawn to run the GCE daemon

### DIFF
--- a/coreos-base/oem-gce/files/units/oem-gce.service
+++ b/coreos-base/oem-gce/files/units/oem-gce.service
@@ -4,6 +4,7 @@ After=local-fs.target network-online.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 Restart=always
 RestartSec=5
 
@@ -11,19 +12,18 @@ RestartSec=5
 KillMode=process
 KillSignal=SIGTERM
 
-ExecStart=/usr/bin/rkt run \
-    --inherit-env=true \
-    --insecure-options=image \
-    --net=host \
-    --stage1-path=/usr/lib/rkt/stage1-images/stage1-fly.aci \
-    --volume=etc,kind=host,source=/etc,readOnly=false \
-    --volume=home,kind=host,source=/home,readOnly=false \
-    --volume=runsystemd,kind=host,source=/run/systemd,readOnly=false \
-    --volume=nsswitch,kind=host,source=/usr/share/google-oslogin/nsswitch.conf,readOnly=true \
-    --mount=volume=nsswitch,target=/usr/share/google-oslogin/nsswitch.conf \
-    /usr/share/oem/flatcar-oem-gce.aci
-
-ExecStopPost=/usr/bin/rkt gc --mark-only
+ExecStartPre=/usr/bin/rm -f /var/lib/flatcar-oem-gce.img
+ExecStartPre=/usr/bin/truncate -s 1G /var/lib/flatcar-oem-gce.img
+ExecStartPre=/usr/sbin/mkfs.ext4 /var/lib/flatcar-oem-gce.img
+ExecStartPre=/usr/bin/rm -rf /var/lib/flatcar-oem-gce
+ExecStartPre=/usr/bin/mkdir -p /var/lib/flatcar-oem-gce
+ExecStartPre=-/usr/bin/umount /var/lib/flatcar-oem-gce.img
+ExecStartPre=/usr/bin/mount /var/lib/flatcar-oem-gce.img /var/lib/flatcar-oem-gce
+ExecStartPre=/usr/bin/tar --directory=/var/lib/flatcar-oem-gce --extract --file=/usr/share/oem/flatcar-oem-gce.aci --strip-components=1 rootfs
+ExecStartPre=/usr/bin/umount /var/lib/flatcar-oem-gce.img
+ExecStart=/usr/bin/systemd-nspawn --keep-unit --register=no --link-journal=no \
+    --machine=oem-gce --bind=/dev/log --bind=/run/systemd --tmpfs=/run/lock --bind=/etc --bind=/home --bind-ro=/usr/share/google-oslogin/nsswitch.conf \
+    --read-only --volatile=overlay --image=/var/lib/flatcar-oem-gce.img /init.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The GCE daemon container was run with rkt from an ACI tar ball.
To replace rkt with systemd-nspawn, extract the tar ball to an image
and run the daemon as systemd-nspawn container.


# How to use

For the release notes:
```
- GCE: The oem-gce.service was ported to use systemd-nspawn instead of rkt.
   A one-time action is required to fetch the new service file because the OEM partition is not updated:
    sudo curl -s -S -f -L -o /etc/systemd/system/oem-gce.service https://raw.githubusercontent.com/kinvolk/coreos-overlay/fe7b0047ef5b634ebe04c9627bbf1ce3008ee5fa/coreos-base/oem-gce/files/units/oem-gce.service && sudo systemctl daemon-reload && sudo systemctl restart oem-gce.service
```

# Testing done

Checked that service runs on a GCE instance with [this image](http://jenkins.infra.kinvolk.io:8080/job/os/job/board/job/packages-matrix/3749/console):
```
systemctl status oem-gce
● oem-gce.service - GCE Linux Agent
     Loaded: loaded (/etc/systemd/system/oem-gce.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2021-04-22 08:29:43 UTC; 1min 1s ago
```