### PR TITLE
Set the default Go version to 1.16

### DIFF
--- a/app-admin/updateservicectl/updateservicectl-9999.ebuild
+++ b/app-admin/updateservicectl/updateservicectl-9999.ebuild
@@ -6,6 +6,7 @@ CROS_WORKON_PROJECT="flatcar-linux/updateservicectl"
 CROS_WORKON_LOCALNAME="updateservicectl"
 CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/updateservicectl"
+COREOS_GO_GO111MODULE="off"
 inherit cros-workon coreos-go
 
 if [[ "${PV}" == 9999 ]]; then

--- a/app-emulation/acbuild/acbuild-9999.ebuild
+++ b/app-emulation/acbuild/acbuild-9999.ebuild
@@ -6,6 +6,7 @@ CROS_WORKON_PROJECT="appc/acbuild"
 CROS_WORKON_REPO="git://github.com"
 CROS_WORKON_LOCALNAME="appc-acbuild"
 COREOS_GO_PACKAGE="github.com/appc/acbuild"
+COREOS_GO_GO111MODULE="off"
 inherit coreos-go toolchain-funcs cros-workon
 
 if [[ "${PV}" == 9999 ]]; then

--- a/app-emulation/cri-tools/cri-tools-1.19.0.ebuild
+++ b/app-emulation/cri-tools/cri-tools-1.19.0.ebuild
@@ -5,7 +5,6 @@ EAPI=7
 
 inherit coreos-go
 
-COREOS_GO_VERSION="go1.15"
 COREOS_GO_PACKAGE="github.com/kubernetes-sigs/cri-tools"
 COREOS_GO_MOD="vendor"
 

--- a/eclass/coreos-go-depend.eclass
+++ b/eclass/coreos-go-depend.eclass
@@ -11,9 +11,9 @@
 #
 # Example:
 # @CODE
-# COREOS_GO_VERSION=go1.15
+# COREOS_GO_VERSION=go1.16
 # @CODE
-export COREOS_GO_VERSION="${COREOS_GO_VERSION:-go1.15}"
+export COREOS_GO_VERSION="${COREOS_GO_VERSION:-go1.16}"
 
 case "${EAPI:-0}" in
 	5|6) DEPEND="dev-lang/go:${COREOS_GO_VERSION#go}=" ;;

--- a/eclass/coreos-go.eclass
+++ b/eclass/coreos-go.eclass
@@ -30,7 +30,7 @@
 #
 # Example:
 # @CODE
-# COREOS_GO_VERSION=go1.15
+# COREOS_GO_VERSION=go1.16
 # @CODE
 
 case "${EAPI:-0}" in


### PR DESCRIPTION
Set the default Go version to 1.16 in coreos-go eclass files, to make ebuilds work with Go 1.16 by default.

Simply remove `COREOS_GO_VERSION` from the ebuild of `app-emulation/cri-tools`, as cri-tools does not belong to special cases of Go versions like Docker.

Set `COREOS_GO111MODULE` to `off` in `app-emulation/acbuild` and `app-admin/updateservicectl` to fix build failures. These packages do not support Go module, because of their old source code.

## How to use

```
./boostrap_sdk
./build_packages
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2464/cldsv/