### PR TITLE
profiles: accept keywords for net-libs/gnutls

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -92,3 +92,5 @@ dev-util/checkbashisms
 =sys-fs/multipath-tools-0.8.5 ~amd64 ~arm64
 
 =app-arch/zstd-1.4.9 ~amd64 ~arm64
+
+=net-libs/gnutls-3.7.1 ~amd64 ~arm64


### PR DESCRIPTION
To be able to build gnutls 3.7.1, which is still not stable, we need to accept keywords `~amd64` and `~arm64`.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/164 .

## How to use

```
emerge-amd64-usr net-libs/gnutls
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2465/cldsv/
