### PR TITLE
sys-kernel/bootengine: make hostname units optional

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="b36e1943b35dac73b15c1105e5657b6459593b95" # flatcar-master
+	CROS_WORKON_COMMIT="c2188288859f404e788e8747746b5f5e43565eea" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Having the hostname units as required by the initrd.target meant that if
the unit failed (for example because the network was or the metadata
service were down), the machine wouldn't start. By making it a "wants"
rather than a "requires" we allow this unit to fail without disrupting
the whole boot.

# Testing done

This already tested when it got committed to the bootengine repo, this change is just the update of the commit in the coreos-overlay repo.
