### PR TITLE
sys-apps/systemd: Fix the patch to update DefaultTasksMax

### DIFF
--- a/sys-apps/systemd/files/0007-core-use-max-for-DefaultTasksMax.patch
+++ b/sys-apps/systemd/files/0007-core-use-max-for-DefaultTasksMax.patch
@@ -1,55 +1,56 @@
-From 7bbbac4b335e4dbb2afa5029f9e1f7dcee493d32 Mon Sep 17 00:00:00 2001
-From: David Michael <david.michael@coreos.com>
-Date: Mon, 25 Jul 2016 15:46:40 -0700
-Subject: [PATCH 4/5] core: use max for DefaultTasksMax
+From 3acaafc6fcd34b272e5249c49e498ff7facb564e Mon Sep 17 00:00:00 2001
+From: Sayan Chowdhury <sayan@kinvolk.io>
+Date: Thu, 22 Apr 2021 20:08:33 +0530
+Subject: [PATCH] core: use max for DefaultTasksMax
 
 Since systemd v228, systemd has a DefaultTasksMax which defaulted
 to 512, later 15% of the system's maximum number of PIDs.  This
 limit is low and a change in behavior that people running services
 in containers will hit frequently, so revert to previous behavior.
+
+Though later the TasksMax was changed in the a dynamic property to
+accommodate stale values.
+
+This change is built on previous patch by David Michael(dm0-).
+
+Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>
 ---
- man/systemd-system.conf.xml | 6 +-----
- src/basic/cgroup-util.h     | 4 ++++
+ man/systemd-system.conf.xml | 2 +-
+ src/core/main.c             | 2 +-
  src/core/system.conf.in     | 2 +-
- 3 files changed, 6 insertions(+), 6 deletions(-)
+ 3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/man/systemd-system.conf.xml b/man/systemd-system.conf.xml
-index 075666ac6b..bcbed4cf59 100644
+index d39928ec23..4d89a68b16 100644
 --- a/man/systemd-system.conf.xml
 +++ b/man/systemd-system.conf.xml
-@@ -361,11 +361,7 @@
+@@ -376,7 +376,7 @@
          <listitem><para>Configure the default value for the per-unit <varname>TasksMax=</varname> setting. See
          <citerefentry><refentrytitle>systemd.resource-control</refentrytitle><manvolnum>5</manvolnum></citerefentry>
          for details. This setting applies to all unit types that support resource control settings, with the exception
 -        of slice units. Defaults to 15% of the minimum of <varname>kernel.pid_max=</varname>, <varname>kernel.threads-max=</varname>
--        and root cgroup <varname>pids.max</varname>.
--        Kernel has a default value for <varname>kernel.pid_max=</varname> and an algorithm of counting in case of more than 32 cores.
--        For example with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 4915,
--        but might be greater in other systems or smaller in OS containers.</para></listitem>
-+        of slice units. Defaults to 100%.</para></listitem>
-       </varlistentry>
++        of slice units. Defaults to 100% of the minimum of <varname>kernel.pid_max=</varname>, <varname>kernel.threads-max=</varname>
+         and root cgroup <varname>pids.max</varname>.
+         Kernel has a default value for <varname>kernel.pid_max=</varname> and an algorithm of counting in case of more than 32 cores.
+         For example with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 4915,
+diff --git a/src/core/main.c b/src/core/main.c
+index 0ddd629851..5e25a1b4b7 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -91,7 +91,7 @@
+ #include <sanitizer/lsan_interface.h>
+ #endif
  
-       <varlistentry>
-diff --git a/src/basic/cgroup-util.h b/src/basic/cgroup-util.h
-index bdc0d0d086..345a99aa5c 100644
---- a/src/basic/cgroup-util.h
-+++ b/src/basic/cgroup-util.h
-@@ -129,6 +129,10 @@ static inline bool CGROUP_BLKIO_WEIGHT_IS_OK(uint64_t x) {
-             (x >= CGROUP_BLKIO_WEIGHT_MIN && x <= CGROUP_BLKIO_WEIGHT_MAX);
- }
+-#define DEFAULT_TASKS_MAX ((TasksMax) { 15U, 100U }) /* 15% */
++#define DEFAULT_TASKS_MAX ((TasksMax) { 100U, 100U }) /* 100% */
  
-+/* Default resource limits */
-+#define DEFAULT_TASKS_MAX_PERCENTAGE            100U /* 100% of PIDs */
-+#define DEFAULT_USER_TASKS_MAX_PERCENTAGE       33U /* 33% of PIDs, 10813 on default settings */
-+
- typedef enum CGroupUnified {
-         CGROUP_UNIFIED_UNKNOWN = -1,
-         CGROUP_UNIFIED_NONE = 0,        /* Both systemd and controllers on legacy */
+ static enum {
+         ACTION_RUN,
 diff --git a/src/core/system.conf.in b/src/core/system.conf.in
-index 40bb548887..c6cddf4f79 100644
+index fa6fb690c7..1e6df17d94 100644
 --- a/src/core/system.conf.in
 +++ b/src/core/system.conf.in
-@@ -52,7 +52,7 @@
+@@ -55,7 +55,7 @@
  #DefaultBlockIOAccounting=no
  #DefaultMemoryAccounting=@MEMORY_ACCOUNTING_DEFAULT@
  #DefaultTasksAccounting=yes
@@ -59,5 +60,6 @@ index 40bb548887..c6cddf4f79 100644
  #DefaultLimitFSIZE=
  #DefaultLimitDATA=
 -- 
-2.26.2
+2.30.2
+
 


### PR DESCRIPTION
The upstream changed the way it handles default value, and
make the property partially dynamic which made the previous patch not work

# Testing done

Local test not done yet. Jenkins CI [running](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2488/cldsv/)


