### PR TITLE
profiles: Add accept keywords for openldap

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -94,3 +94,5 @@ dev-util/checkbashisms
 =app-arch/zstd-1.4.9 ~amd64 ~arm64
 
 =net-libs/gnutls-3.7.1 ~amd64 ~arm64
+
+=net-nds/openldap-2.4.58 ~amd64 ~arm64


### PR DESCRIPTION
# profiles: Add accept keywords for openldap

To be merged with https://github.com/kinvolk/portage-stable/pull/165

# How to use

```bash
emerge-amd64-usr net-nds/openldap
./build_packages
```

# Testing done

Jenkins CI [running](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2513/cldsv/)

