### PR TITLE
profiles: Update the accept keywords for curl 7.76.1

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -96,3 +96,5 @@ dev-util/checkbashisms
 =net-libs/gnutls-3.7.1 ~amd64 ~arm64
 
 =net-nds/openldap-2.4.58 ~amd64 ~arm64
+
+=net-misc/curl-7.76.1 ~amd64 ~arm64


### PR DESCRIPTION
# profiles: Update the accept keywords for curl 7.76.1

To be merged with https://github.com/kinvolk/portage-stable/pull/167

# How to use

```bash
emerge-amd64-usr net-misc/curl
./build_packages
```

# Testing done

Jenkins CI [running](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2515/cldsv/)

