### PR TITLE
coreos-base/coreos-init: flatcar-install, detect device mapper usage

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="d9ec12477ef514ac6c9cfd4182e3b2ede77c5963" # flatcar-master
+	CROS_WORKON_COMMIT="cbb8ec19871c19b9927ea083e68e2e2a5b3f0906" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in a behavior change in the flatcar-install script to
detect if a disk is used through a device mapper entry when searching
for free disks with -s.
https://github.com/kinvolk/init/pull/39

Fixes https://github.com/kinvolk/Flatcar/issues/332
