### PR TITLE
network: don't manage the loopback interface

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="cbb8ec19871c19b9927ea083e68e2e2a5b3f0906" # flatcar-master
+	CROS_WORKON_COMMIT="21b1c15f58803c50d47d99b44f949f6922039cda" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="c2188288859f404e788e8747746b5f5e43565eea" # flatcar-master
+	CROS_WORKON_COMMIT="0e0592b7bedc5047b4cbd0705cef9ca62f812d36" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
- sys-kernel/bootengine: network, don't manage the loopback interface
    This pulls in a change in the systemd network unit to ignore the
    loopback interface instead of managing its state which sometimes causes
    the address to be lost.
    https://github.com/kinvolk/bootengine/pull/24
- coreos-base/coreos-init: systemd/network, don't manage the loopback interface
    This pulls in a change in the systemd network unit to ignore the
    loopback interface instead of managing its state which sometimes causes
    the address to be lost.
    https://github.com/kinvolk/init/pull/40