### PR TITLE
profiles: accept keywords ~amd64 and ~arm64 for libxml2 2.9.12-r2

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -98,3 +98,5 @@ dev-util/checkbashisms
 =net-nds/openldap-2.4.58 ~amd64 ~arm64
 
 =net-misc/curl-7.76.1 ~amd64 ~arm64
+
+=dev-libs/libxml2-2.9.12-r2 ~amd64 ~arm64


### PR DESCRIPTION
To be able to build `dev-libs/libxml2` 2.9.12-r2, we need to accept both `~amd64` and `~arm64` for libxml2.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/171 .

## How to use

```
emerge-amd64-usr dev-libs/libxml2
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2696/cldsv/