### PR TITLE
sys-apps/baselayout: filter out bullet point when parsing failed units (for flatcar-2765)

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="abbf6b604659f780846a881a6c6bafbcd8e2da87" # flatcar-master
+	CROS_WORKON_COMMIT="003645f150af7a331307a3a472ae1f7f1014b0ba" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
The output of "systemctl list-units --state=failed --no-legend" still
contains the bullet point which is not expected and ends up being taken
as the unit name which was previously on the start of the line.
Filter the bullet point out to stay compatible with the old behavior in
case upstream would remove the bullet point again.

This pulls in
https://github.com/kinvolk/baselayout/pull/16/
