### PR TITLE
Revert "profiles: Update the accept keywords for curl 7.76.1"

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -97,6 +97,4 @@ dev-util/checkbashisms
 
 =net-nds/openldap-2.4.58 ~amd64 ~arm64
 
-=net-misc/curl-7.76.1 ~amd64 ~arm64
-
 =dev-libs/libxml2-2.9.12-r2 ~amd64 ~arm64


### PR DESCRIPTION
This reverts commit 8d56fd17957540e764ca491285776d2dbb73c38e.

`curl-7.77` is [stable](https://packages.gentoo.org/packages/net-misc/curl).

To be merged with: https://github.com/kinvolk/portage-stable/pull/175

## Testing done

- locally built:
```
core@localhost ~ $ curl --version
curl 7.77.0 (x86_64-cros-linux-gnu) libcurl/7.77.0 OpenSSL/1.1.1k zlib/1.2.11 nghttp2/1.41.0
Release-Date: 2021-05-26
Protocols: dict file ftp ftps http https imap imaps mqtt pop3 pop3s rtsp smtp smtps tftp
Features: AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz NTLM SPNEGO SSL TLS-SRP UnixSockets
```
- [Jenkins](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2851/cldsv/): :green_circle:

