### PR TITLE
coreos-base/oem-ec2-compat: Add NVIDIA support for AWS Pro

### DIFF
--- a/coreos-base/oem-ec2-compat/files/base/base-aws-pro.ign
+++ b/coreos-base/oem-ec2-compat/files/base/base-aws-pro.ign
@@ -11,6 +11,14 @@
           "source": "oem:///eks/bootstrap.sh"
         },
         "mode": 493
+      },
+      {
+        "filesystem": "root",
+        "path": "/etc/systemd/system/nvidia.service",
+        "contents": {
+          "source": "oem:///units/nvidia.service"
+        },
+        "mode": 292
       }
     ]
   },
@@ -18,6 +26,10 @@
     "units": [
       {
         "name": "coreos-metadata-sshkeys@.service",
+        "enabled": true
+      },
+      {
+        "name": "nvidia.service",
         "enabled": true
       }
     ]

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
@@ -20,7 +20,10 @@ REQUIRED_USE="^^ ( ec2 openstack brightbox aws_pro )"
 #       ec2? ( app-emulation/amazon-ssm-agent )
 #"
 RDEPEND="
-       aws_pro? ( coreos-base/flatcar-eks )
+       aws_pro? (
+        coreos-base/flatcar-eks
+        x11-drivers/nvidia-drivers
+       )
 "
 
 # no source directory


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# coreos-base/oem-ec2-compat: Add NVIDIA support for AWS Pro

## How to use

Build an AWS Pro image and check the logs of  `nvidia.service`

## Testing done
CI Passed http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2838/cldsv/

```
ip-172-31-6-218 core # nvidia-smi 
Tue Jun 29 15:28:43 2021       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 460.73.01    Driver Version: 460.73.01    CUDA Version: 11.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla M60           Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   33C    P0    37W / 150W |      0MiB /  7618MiB |     99%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```
