### PR TITLE
sys-libs/glibc-2.33: mask for now to un-break build

### DIFF
--- a/sys-libs/glibc/glibc-2.33-r1.ebuild
+++ b/sys-libs/glibc/glibc-2.33-r1.ebuild
@@ -23,7 +23,7 @@ PATCH_DEV=dilfridge
 if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
-	KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 	SRC_URI="mirror://gnu/glibc/${P}.tar.xz"
 	SRC_URI+=" https://dev.gentoo.org/~${PATCH_DEV}/distfiles/${P}-patches-${PATCH_VER}.tar.xz"
 fi


### PR DESCRIPTION
We experience an issue with glibc-2.33 which causes all binaries in the
OS image to end up not stripped, which would increase the size of the OS
image threefold.

The change masks glibc-2.33 for all architectures, so the build will
default on glibc-2.32 until we have fixed the issue.