### PR TITLE
coreos-base/update_engine: bump commit ID

### DIFF
--- a/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/coreos-base/update_engine/update_engine-9999.ebuild
@@ -9,7 +9,7 @@ AUTOTOOLS_AUTORECONF=1
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="6543c95112a92276997fbe123fb2876c65a7efd7" # flatcar-master
+	CROS_WORKON_COMMIT="c3c45a040306be554b4292c2d0194700ac3c40b0" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
related to: https://github.com/kinvolk/update_engine/pull/10, https://github.com/kinvolk/Flatcar/issues/356

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

## How to use

```
emerge-amd64-usr -av coreos-base/update_engine
```

## Testing done

- local build
- jenkins (:large_blue_circle:): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2947/cldsv/