### PR TITLE
coreos-base/coreos-init: add udev systemd tag for Azure storage devices

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="21b1c15f58803c50d47d99b44f949f6922039cda" # flatcar-master
+	CROS_WORKON_COMMIT="6fc3acc21dd95a192fc5077082f1e84bd2a4102e" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/41

## How to use
Run `ls /boot` and see that it works

## Testing done

http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2968/cldsv/
and manually with `kola spawn`:
```
[bound] core@jenkins-azure-bd0ba49349 ~ $ ls /boot
EFI  boot  flatcar  xen
[bound] core@jenkins-azure-bd0ba49349 ~ $ journalctl -f
-- Journal begins at Wed 2021-07-07 10:12:57 UTC. --
Jul 07 10:14:45 jenkins-azure-bd0ba49349 sshd[1291]: pam_unix(sshd:session): session opened for user core(uid=500) by (uid=0)
Jul 07 10:14:45 jenkins-azure-bd0ba49349 systemd[1]: Started Session 9 of user core.
Jul 07 10:14:45 jenkins-azure-bd0ba49349 systemd-logind[960]: New session 9 of user core.
Jul 07 10:15:48 jenkins-azure-bd0ba49349 systemd[1]: boot.automount: Got automount request for /boot, triggered by 1309 (ls)
Jul 07 10:15:48 jenkins-azure-bd0ba49349 systemd[1]: Starting File System Check on /dev/disk/by-label/EFI-SYSTEM...
Jul 07 10:15:49 jenkins-azure-bd0ba49349 systemd-fsck[1312]: fsck.fat 4.1 (2017-01-24)
Jul 07 10:15:49 jenkins-azure-bd0ba49349 systemd-fsck[1312]: /dev/sda1: 790 files, 135818/258078 clusters
Jul 07 10:15:49 jenkins-azure-bd0ba49349 systemd[1]: Finished File System Check on /dev/disk/by-label/EFI-SYSTEM.
Jul 07 10:15:49 jenkins-azure-bd0ba49349 systemd[1]: Mounting Boot partition...
Jul 07 10:15:49 jenkins-azure-bd0ba49349 systemd[1]: Mounted Boot partition.
$ udevadm info /dev/sda /dev/sda1 | grep TAGS
E: TAGS=:systemd:
E: CURRENT_TAGS=:systemd:
E: TAGS=:systemd:
E: CURRENT_TAGS=:systemd:
```