### PR TITLE
app-admin/updateservicectl: sync with current main - 2021-07-05

### DIFF
--- a/app-admin/updateservicectl/updateservicectl-9999.ebuild
+++ b/app-admin/updateservicectl/updateservicectl-9999.ebuild
@@ -2,22 +2,22 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/updateservicectl"
+CROS_WORKON_PROJECT="kinvolk/updateservicectl"
 CROS_WORKON_LOCALNAME="updateservicectl"
 CROS_WORKON_REPO="git://github.com"
-COREOS_GO_PACKAGE="github.com/coreos/updateservicectl"
-COREOS_GO_GO111MODULE="off"
+COREOS_GO_PACKAGE="github.com/kinvolk/updateservicectl"
+COREOS_GO_GO111MODULE="on"
 inherit cros-workon coreos-go
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="b0e1d578b42082b5bb5ccb1b6e6d526843df3f46" # v2.1.0
+	CROS_WORKON_COMMIT="6a4ff4ca879082c07353dd379439c437cbe27e18" # main
 	KEYWORDS="amd64 arm64"
 fi
 
 DESCRIPTION="CoreUpdate Management CLI"
-HOMEPAGE="https://github.com/coreos/updateservicectl"
+HOMEPAGE="https://github.com/kinvolk/updateservicectl"
 SRC_URI=""
 
 LICENSE="Apache-2.0"


### PR DESCRIPTION
Update commit to `6a4ff4ca879082c07353dd379439c437cbe27e18`, to sync with
the current main branch.
Pulls in https://github.com/kinvolk/updateservicectl/pull/6 .

Also update Go import paths to `github.com/kinvolk/updateservicectl`.

Also set `COREOS_GO_GO111MODULE=on` because updateservicectl now relies
on Go module.

## How to use

(only in SDK)
```
sudo emerge app-admin/updateservicectl
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2976/cldsv/