### PR TITLE
profiles: accept ~amd64 & ~arm64 for libgcrypt-1.9.3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -98,3 +98,5 @@ dev-util/checkbashisms
 =net-nds/openldap-2.4.58 ~amd64 ~arm64
 
 =dev-libs/libxml2-2.9.12-r2 ~amd64 ~arm64
+
+=dev-libs/libgcrypt-1.9.3 ~amd64 ~arm64


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

related to: https://github.com/kinvolk/portage-stable/pull/185

## Testing done

- jenkins (:large_blue_circle:): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2977/cldsv/