### PR TITLE
net-misc/curl: enable telnet protocol support

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -11,7 +11,7 @@ dev-libs/libxml2	-python
 dev-util/perf		tui -doc
 dev-vcs/git		webdav curl bash-completion
 # We don't want any driver/hw rendering on the host
-net-misc/curl		kerberos threads
+net-misc/curl		kerberos threads telnet
 net-misc/iputils	arping tracepath traceroute
 sys-devel/gettext	-git
 app-emulation/qemu	aio caps curl ncurses png python threads uuid vhost-net virtfs vnc -xkb -slirp -jpeg qemu_softmmu_targets_x86_64 qemu_softmmu_targets_aarch64 python_targets_python3_7


### PR DESCRIPTION
Add telnet useflag directly in the package.use file

Tested by building the image and running the curl command `curl -v telnet://towel.blinkenlights.nl:23`
```
*   Trying 213.136.8.188:23...
*   Trying 2001:7b8:666:ffff::1:42:23...
* Immediate connect fail for 2001:7b8:666:ffff::1:42: Network is unreachable
```