### PR TITLE
.github: list only ebuilds with a unique VERSION_OLD for runc

### DIFF
--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -24,7 +24,7 @@ DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p" app-e
 
 # we need to update not only the main ebuild file, but also its CONTAINERD_COMMIT,
 # which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream containerd.
-containerdEbuildOldSymlink=$(ls -1 app-emulation/containerd/containerd-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
+containerdEbuildOldSymlink=$(ls -1 app-emulation/containerd/containerd-${VERSION_OLD}.ebuild)
 containerdEbuildNewSymlink="app-emulation/containerd/containerd-${VERSION_NEW}.ebuild"
 containerdEbuildMain="app-emulation/containerd/containerd-9999.ebuild"
 git mv ${containerdEbuildOldSymlink} ${containerdEbuildNewSymlink}

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -22,7 +22,7 @@ fi
 
 # we need to update not only the main ebuild file, but also its DOCKER_GITCOMMIT,
 # which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream docker-ce.
-dockerEbuildOldSymlink=$(ls -1 app-emulation/docker/docker-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
+dockerEbuildOldSymlink=$(ls -1 app-emulation/docker/docker-${VERSION_OLD}.ebuild)
 dockerEbuildNewSymlink="app-emulation/docker/docker-${VERSION_NEW}.ebuild"
 dockerEbuildMain="app-emulation/docker/docker-9999.ebuild"
 git mv ${dockerEbuildOldSymlink} ${dockerEbuildNewSymlink}

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -21,7 +21,7 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-git mv $(ls -1 sys-kernel/coreos-firmware/coreos-firmware-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "sys-kernel/coreos-firmware/coreos-firmware-${VERSION_NEW}.ebuild"
+git mv $(ls -1 sys-kernel/coreos-firmware/coreos-firmware-${VERSION_OLD}.ebuild) "sys-kernel/coreos-firmware/coreos-firmware-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -25,7 +25,7 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "dev-lang/go/go-${VERSION_NEW}.ebuild"
+git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}.ebuild) "dev-lang/go/go-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -16,7 +16,7 @@ pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 # Get the original runc version, including official releases and rc versions.
 # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
 # so that sort -V can give the newest version including non-rc versions.
-VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*\.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | sed '/-/!{s/$/_/}' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
+VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*\.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | tr '_' '-' | sed '/-/!{s/$/_/}' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   echo "already the latest Runc, nothing to do"
   UPDATE_NEEDED=0

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -23,7 +23,7 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-runcEbuildOld=$(ls -1 app-emulation/docker-runc/docker-runc-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
+runcEbuildOld=$(ls -1 app-emulation/docker-runc/docker-runc-${VERSION_OLD}.ebuild)
 runcEbuildNew="app-emulation/docker-runc/docker-runc-${VERSION_NEW}.ebuild"
 git mv ${runcEbuildOld} ${runcEbuildNew}
 sed -i "s/${VERSION_OLD}/${VERSION_NEW}/g" ${runcEbuildNew}

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -24,7 +24,7 @@ fi
 find profiles -name 'package.*' | xargs sed -i "s/=dev-lang\/rust-${VERSION_OLD}/=dev-lang\/rust-${VERSION_NEW}/"
 
 pushd "dev-lang/rust" >/dev/null || exit
-git mv $(ls -1 rust-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "rust-${VERSION_NEW}.ebuild"
+git mv $(ls -1 rust-${VERSION_OLD}.ebuild) "rust-${VERSION_NEW}.ebuild"
 popd >/dev/null || exit
 
 popd >/dev/null || exit


### PR DESCRIPTION
Before passing runc versions to `sed '/-/!{s/$/_/}'`, we need to replace `_` with `-`, because runc tarball files already have names like `1.0.0_rc2`.
Without the fix, version sort would `1.0.0` come before `1.0.0_rc2`, which is not expected in the later steps.

Due to unnecessary wildcard listings, ebuild files including all rc or beta are being listed.
Since `VERSION_OLD` is already generated as a unique version, we do not need to list multiple files to filter by running `head -n1` etc. We just need to use only the specific ebuild.
Simply list only the unique ebuild file.