### PR TITLE
coreos-base/coreos-init: prevent networkd interference with cilium_vxlan

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="3960a476a09a96ef8130052e144f9000d4d2f31e" # flatcar-master
+	CROS_WORKON_COMMIT="bafab09614c67b4006187e21baf938bc28f24558" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/43

**Note:** To be ported to all channels, either with introducing separate branches for `init` or by bringing the following changes along:
https://github.com/kinvolk/init/pull/41
https://github.com/kinvolk/init/pull/42