### PR TITLE
coreos-base/oem-gce: grant CAP_NET_ADMIN to set routes for LB

### DIFF
--- a/coreos-base/oem-gce/files/units/oem-gce.service
+++ b/coreos-base/oem-gce/files/units/oem-gce.service
@@ -22,7 +22,7 @@ ExecStartPre=/usr/bin/mount /var/lib/flatcar-oem-gce.img /var/lib/flatcar-oem-gc
 ExecStartPre=/usr/bin/tar --directory=/var/lib/flatcar-oem-gce --extract --file=/usr/share/oem/flatcar-oem-gce.aci --strip-components=1 rootfs
 ExecStartPre=/usr/bin/umount /var/lib/flatcar-oem-gce.img
 ExecStart=/usr/bin/systemd-nspawn --keep-unit --register=no --link-journal=no \
-    --machine=oem-gce --bind=/dev/log --bind=/run/systemd --tmpfs=/run/lock --bind=/etc --bind=/home --bind-ro=/usr/share/google-oslogin/nsswitch.conf \
+    --machine=oem-gce --capability=CAP_NET_ADMIN --bind=/dev/log --bind=/run/systemd --tmpfs=/run/lock --bind=/etc --bind=/home --bind-ro=/usr/share/google-oslogin/nsswitch.conf \
     --read-only --volatile=overlay --image=/var/lib/flatcar-oem-gce.img /init.sh
 
 [Install]


### PR DESCRIPTION
With the switch from rkt to systemd-nspawn the ability for the service
to set the routing entries for the TCP load balancer got lost,
resulting in an unreachable LB as reported in
https://github.com/kinvolk/Flatcar/issues/459

The fix also reported there is to retain CAP_NET_ADMIN when starting
the service.

## How to use

## Testing done

Regular release tests: http://localhost:9091/job/os/job/manifest/3159/cldsv/