### PR TITLE
docker/torcx: disable SELinux by default on `dockerd` wrapper script

### DIFF
--- a/app-arch/torcx/files/dockerd-wrapper.sh
+++ b/app-arch/torcx/files/dockerd-wrapper.sh
@@ -34,8 +34,8 @@ parse_docker_args "$@"
 USE_SELINUX=""
 # Do not override selinux if it is already explicitly configured.
 if [[ -z "${ARG_SELINUX}" ]]; then
-        # If unspecified, default on
-        USE_SELINUX="--selinux-enabled"
+        # If unspecified, default off
+        USE_SELINUX="--selinux-enabled=false"
 fi
 
 exec dockerd "$@" ${USE_SELINUX}

--- a/app-emulation/docker/files/dockerd
+++ b/app-emulation/docker/files/dockerd
@@ -34,8 +34,8 @@ parse_docker_args "$@"
 USE_SELINUX=""
 # Do not override selinux if it is already explicitly configured.
 if [[ -z "${ARG_SELINUX}" ]]; then
-        # If unspecified, default on
-        USE_SELINUX="--selinux-enabled"
+        # If unspecified, default off
+        USE_SELINUX="--selinux-enabled=false"
 fi
 
 exec dockerd "$@" ${USE_SELINUX}


### PR DESCRIPTION
In https://github.com/kinvolk/coreos-overlay/pull/1055 we disabled `SELinux` for Docker but we did not port this change to the deprecated scripts which enable by default `SELinux`.

## Testing done

We have a test for this `docker.lib-coreos-dockerd-compat` but we did not catch the failure because we explicitely set the `--selinux-enabled` to false - which overrides the default behavior of `dockerd` script. (see: https://github.com/kinvolk/mantle/commit/9101e7016fc1b52ed690e4201ece891b4f863a51#diff-52b597358285b8b043950f2001c39f118a56284357fb13493292ad11d9aa224cR183)

Closes: https://github.com/kinvolk/Flatcar/issues/457
