### PR TITLE
profiles: Remove libarchive-3.3.1 from ACCEPT_KEYWORDS

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -2,7 +2,6 @@
 # Keep these in alphabetical order.
 
 =app-arch/bzip2-1.0.6-r8 ~arm64
-=app-arch/libarchive-3.3.1 ~arm64
 ~app-arch/pbzip2-1.1.12 ~arm64
 =app-arch/pigz-2.3.3 ~arm64
 =app-crypt/mit-krb5-1.14.2 ~arm64


### PR DESCRIPTION
# profiles: Remove libarchive-3.3.1 from ACCEPT_KEYWORDS

## How to use

```bash
emerge-amd64-usr app-arch/libarchive
```

## Testing done

CI is running, ~http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3170/cldsv/~
http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3187/cldsv/

To be merged with https://github.com/kinvolk/portage-stable/pull/192
