### PR TITLE
amazon-ssm-agent: re-add dependency to oem-ec2-compat

### DIFF
--- a/app-emulation/amazon-ssm-agent/amazon-ssm-agent-2.3.1319.0-r1.ebuild
+++ b/app-emulation/amazon-ssm-agent/amazon-ssm-agent-2.3.1319.0-r1.ebuild
@@ -28,23 +28,25 @@ src_prepare() {
 }
 
 src_compile() {
+	go_export
+
 	# this is replication of commands from the vendor makefile
 	# but without network activity during build phase
 	local GO_LDFLAGS="-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs"
 	export GOPATH="${WORKDIR}/${PN}-${PV}"
 	export GO111MODULE="off"
 	# set agent release version
-	BRAZIL_PACKAGE_VERSION=${PV} go run ./agent/version/versiongenerator/version-gen.go
+	BRAZIL_PACKAGE_VERSION=${PV} ${EGO} run ./agent/version/versiongenerator/version-gen.go
 	# build all the tools
-	go build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
+	${EGO} build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
 		-o bin/amazon-ssm-agent ./agent || die
-	go build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
+	${EGO} build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
 		-o bin/ssm-cli ./agent/cli-main || die
-	go build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
+	${EGO} build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
 		-o bin/ssm-document-worker ./agent/framework/processor/executer/outofproc/worker || die
-	go build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
+	${EGO} build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
 		-o bin/ssm-session-logger ./agent/session/logging || die
-	go build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
+	${EGO} build -v -ldflags "${GO_LDFLAGS}" -buildmode=pie \
 		-o bin/ssm-session-worker ./agent/framework/processor/executer/outofproc/sessionworker || die
 }
 

--- a/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
+++ b/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
@@ -7,6 +7,31 @@
       {
         "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
+      },
+      {
+        "name": "amazon-ssm-agent.service",
+        "enabled": true,
+        "contents": "[Unit]\nDescription=amazon-ssm-agent\nAfter=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory=/usr/share/oem\nExecStart=/usr/share/oem/amazon-ssm-agent\nKillMode=process\nRestart=on-failure\nRestartForceExitStatus=SIGPIPE\nRestartSec=15min\n\n[Install]\nWantedBy=multi-user.target\n"
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "filesystem": "root",
+        "path": "/etc/amazon/ssm/amazon-ssm-agent.json",
+        "contents": {
+          "source": "oem:///ssm/amazon-ssm-agent.json.template"
+        },
+        "mode": 292
+      },
+      {
+        "filesystem": "root",
+        "path": "/etc/amazon/ssm/seelog.xml",
+        "contents": {
+          "source": "oem:///ssm/seelog.xml.template"
+        },
+        "mode": 292
       }
     ]
   }

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
@@ -13,21 +13,12 @@ KEYWORDS="amd64 arm64 x86"
 IUSE="ec2 openstack brightbox aws_pro"
 REQUIRED_USE="^^ ( ec2 openstack brightbox aws_pro )"
 
-# TODO: The AWS SSM Agent is currently too big for the OEM partition
-# but if it fits, uncomment the following and revert
-# b6abb59c544be13e923a3e7240b5c9395c281fca
-#RDEPEND="
-#       ec2? ( app-emulation/amazon-ssm-agent )
-#"
 RDEPEND="
+       ec2? ( app-emulation/amazon-ssm-agent )
        aws_pro? (
         coreos-base/flatcar-eks
         x11-drivers/nvidia-drivers
        )
-"
-
-RDEPEND="
-	app-emulation/amazon-ssm-agent
 "
 
 # no source directory

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
@@ -26,6 +26,10 @@ RDEPEND="
        )
 "
 
+RDEPEND="
+	app-emulation/amazon-ssm-agent
+"
+
 # no source directory
 S="${WORKDIR}"
 


### PR DESCRIPTION
# amazon-ssm-agent: re-add dependency to oem-ec2-compat

The binaries were too big to fit on our 128MB OEM partition. Now that the OEM partition is compressed-btrfs it fits again, so re-add the dependency to oem-ec2-compat.

The other half of the PR are cross-compilation fixes. The ebuild was not exporting GOARCH and was making use of latest go. When built for arm64, host binaries were produced. The ebuild has been fixed to cross-compile correctly.

Related: https://github.com/kinvolk/Flatcar/issues/107

## How to use

```
emerge-arm64-usr amazon-ssm-agent
./build_image
./image_to_vm --format=ami
```

## Testing done

Build tested, and tested that the binaries fit on the OEM partition.