### PR TITLE
coreos-base/coreos-init: embed new subkey in flatcar-install

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="bafab09614c67b4006187e21baf938bc28f24558" # flatcar-master
+	CROS_WORKON_COMMIT="76f2c3328c0ddcbb86091185560ebe0c9b39d835" # flatcar-2905-backport
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
    https://github.com/kinvolk/init/pull/45
    but from a backport branch "flatcar-2905-backport".


I had to introduce a new branch because the motd changes for cgroupv2 were already merged.

This here is going to be picked for flatcar-2905, flatcar-2942, and flatcar-2955