### PR TITLE
sec-policy/selinux-virt: add rules to run `flannel` with SELinux enforced mode

### DIFF
--- a/sec-policy/selinux-virt/files/virt.patch
+++ b/sec-policy/selinux-virt/files/virt.patch
@@ -36,4 +36,4 @@ index 256ea58..f72fbba 100644
 +allow svirt_lxc_net_t var_lib_t:file { entrypoint execute execute_no_trans };
 +allow svirt_lxc_net_t kernel_t:fifo_file { getattr ioctl read write open append };
 +allow svirt_lxc_net_t initrc_t:fifo_file { getattr ioctl read write open append };
-+
++filetrans_pattern(kernel_t, etc_t, svirt_lxc_file_t, dir, "cni");

--- a/sec-policy/selinux-virt/files/virt.patch
+++ b/sec-policy/selinux-virt/files/virt.patch
@@ -1,7 +1,7 @@
-index 4943ad79d..c89bb5c0c 100644
+index 4943ad79d..8b0ed779e 100644
 --- services/virt.te
 +++ services/virt.te
-@@ -1377,3 +1377,38 @@ sysnet_dns_name_resolve(virtlogd_t)
+@@ -1377,3 +1377,41 @@ sysnet_dns_name_resolve(virtlogd_t)
  
  virt_manage_log(virtlogd_t)
  virt_read_config(virtlogd_t)
@@ -40,3 +40,6 @@ index 4943ad79d..c89bb5c0c 100644
 +
 +# this is required by flanneld
 +allow svirt_lxc_net_t kernel_t:system { module_request };
++
++# required by flanneld to write into /run/flannel/subnet.env
++filetrans_pattern(kernel_t, var_run_t, svirt_lxc_file_t, dir, "flannel");

--- a/sec-policy/selinux-virt/files/virt.patch
+++ b/sec-policy/selinux-virt/files/virt.patch
@@ -1,7 +1,7 @@
-index 256ea58..f72fbba 100644
+index 4943ad79d..c89bb5c0c 100644
 --- services/virt.te
 +++ services/virt.te
-@@ -1378,3 +1378,35 @@ sysnet_dns_name_resolve(virtlogd_t)
+@@ -1377,3 +1377,38 @@ sysnet_dns_name_resolve(virtlogd_t)
  
  virt_manage_log(virtlogd_t)
  virt_read_config(virtlogd_t)
@@ -37,3 +37,6 @@ index 256ea58..f72fbba 100644
 +allow svirt_lxc_net_t kernel_t:fifo_file { getattr ioctl read write open append };
 +allow svirt_lxc_net_t initrc_t:fifo_file { getattr ioctl read write open append };
 +filetrans_pattern(kernel_t, etc_t, svirt_lxc_file_t, dir, "cni");
++
++# this is required by flanneld
++allow svirt_lxc_net_t kernel_t:system { module_request };


### PR DESCRIPTION
In this PR, we provide another `virt` rules to have `flannel` correctly running with enforced SELinux.

## How to use

```
emerge-amd64-usr -av sec-policy/selinux-virt
// run SELinux in enforced mode
// run kubernetes with Flannel as CNI
```

## Testing done
- ran the kola kubeadm flannel tests (from this PR: https://github.com/kinvolk/mantle/pull/196 or https://github.com/kinvolk/mantle/pull/205)
```
    --- PASS: kubeadm.v1.21.0.flannel.base/node_readiness (30.97s)
    --- PASS: kubeadm.v1.21.0.flannel.base/nginx_deployment (21.64s)
```
- CI :large_blue_circle: : http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3265/

Closes: https://github.com/kinvolk/Flatcar/issues/476

Also related to: https://github.com/flannel-io/flannel/issues/945, https://github.com/flannel-io/flannel/issues/709

## Note

@kinvolk/flatcar-maintainers how should we proceed with the following commits ? Should I squash them into one single commit `sec-policy/selinux-virt: apply flatcar changes` with a merge of the bodies ?