### PR TITLE
sys-kernel/bootengine: finish network-cleanup.service before rootfs switch

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="0e0592b7bedc5047b4cbd0705cef9ca62f812d36" # flatcar-master
+	CROS_WORKON_COMMIT="18528abbbba7502aa423d4a4539aa219e1f2708b" # flatcar-2905-backport
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/bootengine/pull/27
from a backport branch "flatcar-2905-backport".

Should also be done for flatcar-2942