### PR TITLE
Compile Azure OEM contents for all boards

### DIFF
--- a/app-emulation/wa-linux-agent/wa-linux-agent-2.2.46.ebuild
+++ b/app-emulation/wa-linux-agent/wa-linux-agent-2.2.46.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 DESCRIPTION="Windows Azure Linux Agent"
 HOMEPAGE="https://github.com/Azure/WALinuxAgent"
-KEYWORDS="amd64"
+KEYWORDS="amd64 arm64"
 SRC_URI="${HOMEPAGE}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/coreos-base/oem-azure/oem-azure-2.2.46.ebuild
+++ b/coreos-base/oem-azure/oem-azure-2.2.46.ebuild
@@ -9,7 +9,7 @@ SRC_URI=""
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 arm64"
 IUSE=""
 
 # no source directory

--- a/coreos-devel/board-packages/board-packages-0.0.1.ebuild
+++ b/coreos-devel/board-packages/board-packages-0.0.1.ebuild
@@ -21,12 +21,10 @@ DEPEND=""
 RDEPEND="
 	amd64? (
 		app-emulation/open-vm-tools
-		app-emulation/wa-linux-agent
 		coreos-base/coreos-oem-gce
 		coreos-base/flatcar-eks
 		coreos-base/nova-agent-container
 		coreos-base/nova-agent-watcher
-		dev-lang/python-oem
 		x11-drivers/nvidia-drivers
 	)
 	arm64? (
@@ -34,6 +32,8 @@ RDEPEND="
 		sys-firmware/edk2-ovmf
 	)
 	app-emulation/amazon-ssm-agent
+	app-emulation/wa-linux-agent
 	coreos-base/coreos
 	coreos-base/coreos-dev
+	dev-lang/python-oem
 	"


### PR DESCRIPTION
While not used at the moment we still can lift the restriction to only
compile for the amd64 board.


## How to use/Testing done

Build all packages and run the `image_to_vm.sh` script for Azure