### PR TITLE
sys-apps/ignition: Fix null pointer deref crash for OEM FS

### DIFF
--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -12,7 +12,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="4014d935523be7730a6e003020505197e04ed5bd" # flatcar-master
+	CROS_WORKON_COMMIT="f50a2cc253e8775c694c5710fd1983a30829c133" # TODO: flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/ignition/pull/25

## How to use


## Testing done

Ongoing: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3333/