### PR TITLE
x11-drivers/nvidia-drivers: Add runtime dependencies

### DIFF
--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.57.02.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.57.02.ebuild
@@ -15,7 +15,21 @@ IUSE=""
 # no source directory
 S="${WORKDIR}"
 
-RDEPEND=""
+# The install-nvidia script is using emerge-gitclone, but this script is only
+# invoked within the developer container, so we don't need to add the
+# coreos-base/gmerge package here. All the dependencies below come from the
+# setup-nvidia script, which is run on the host.
+RDEPEND="
+app-arch/bzip2
+app-shells/bash
+net-misc/curl
+sys-apps/coreutils
+sys-apps/grep
+sys-apps/kmod
+sys-apps/pciutils
+sys-apps/systemd
+sys-libs/glibc
+"
 
 src_install() {
   insinto "/usr/share/oem"


### PR DESCRIPTION
When I was renaming the coreos-base/gmerge package, I noticed that nvidia drivers is using a bunch of stuff at runtime (in `setup-nvidia`), but nothing was specified in RDEPENDS. I felt like it should be filled, but not sure.

@sayanchowdhury : Does it make sense, before trying to run this thing in CI?