### PR TITLE
Add app-arch/lbzip2 to the coreos ebuild dependencies

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="fe2a32d2736c359a6911cc22bc42007ac97c5b10" # flatcar-master
+	CROS_WORKON_COMMIT="101e6c71ee2a07ef591eff3d9122a391713dbbf0" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -95,6 +95,7 @@ RDEPEND="${RDEPEND}
 	app-admin/sudo
 	app-admin/toolbox
 	app-arch/gzip
+	app-arch/lbzip2
 	app-arch/tar
 	app-arch/torcx
 	app-arch/unzip


### PR DESCRIPTION
# Add app-arch/lbzip2 to the coreos ebuild dependencies

## Testing done

`emerge-amd64-usr coreos-base/coreos`
`./build_image`
Then checked in the flatcar instance that there is `lbzip2` in the.
