### PR TITLE
app-misc/ca-certificates: Port the python script to python3

### DIFF
--- a/app-misc/ca-certificates/ca-certificates-3.27.1-r2.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-3.27.1-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python3_6 )
 inherit python-any-r1 systemd
 
 RTM_NAME="NSS_${PV//./_}_RTM"


### PR DESCRIPTION
It produces files with the same contents as the python2 version of the
script, but the filename handling is a bit different wrt. filenames
with weird, non-unicode characters. But overall, it does not affect
anything.

I verified that the contents produces by the script are the same by running something like `sha512sum *.pem | cut -f1 -d' ' | sha512sum` (cut here is to only get the sum and discard the filename) in `/usr/share/ca-certificates` on images with pem files produced by old and new version of the script. The difference in filename handling is as below:

old:
![Screenshot from 2021-08-27 13-43-11](https://user-images.githubusercontent.com/96081/131123146-fd632d23-ae67-47b4-bf01-55f4ab497976.png)
new:
![Screenshot from 2021-08-27 13-43-47](https://user-images.githubusercontent.com/96081/131123174-a1452669-ae08-4bba-aad5-e0ff81900693.png)

CI: http://localhost:9091/job/os/job/manifest/3443/cldsv/