### PR TITLE
profiles: enable 'audit' use flag for sys-libs/pam

### DIFF
--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -17,7 +17,7 @@ sys-apps/smartmontools	minimal
 sys-block/parted        device-mapper
 sys-fs/lvm2		-lvm1 -readline
 sys-libs/ncurses	minimal
-sys-libs/pam        -berkdb
+sys-libs/pam		-berkdb audit
 sys-libs/gdbm		berkdb
 
 # enable journal gateway and container features


### PR DESCRIPTION
# build sys-libs/pam with audit support

This change results in building the pam_tty_audit module additionally, nothing else.
Related to https://github.com/kinvolk/Flatcar/issues/485.

## Testing done

```
./build_packages
./build_image
```