### PR TITLE
coreos/config: add fix for perl cross-compilation

### DIFF
--- a/coreos/config/env/dev-lang/perl
+++ b/coreos/config/env/dev-lang/perl
@@ -1,0 +1,5 @@
+if [[ ${EBUILD_PHASE} == configure ]]; then
+  if tc-is-cross-compiler; then
+    append-cflags "-fwrapv -fno-strict-aliasing"
+  fi
+fi


### PR DESCRIPTION
# dev-lang/perl: fix cross-compiled perl segfault.

Current cross builds of perl segfault on simple operations such as `perl -V`.
This appears to be due to the cross-build not getting `-fwrapv -fno-strict-aliasing`
passed from the configure script. While we try to get this fixed upstream, we
can monkeypatch our old version of perl to fix this.

Upstream PR: https://github.com/gentoo/gentoo/pull/22167
Related issue: https://github.com/kinvolk/Flatcar/issues/490

## How to use

```
emerge-amd64-usr perl
```

## Testing done

```
sudo mount --bind /dev /build/amd64-usr/dev
sudo chroot /build/amd64-usr/ perl -V
```
Output:
```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "C.UTF8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Summary of my perl5 (revision 5 version 26 subversion 2) configuration:
```
Previously this would result in a segfault.

Added a call to `perl -V` to the dev-container test and ran CI, test passed (previously fail):
http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3441/cldsv/