### PR TITLE
coreos-base/coreos-init: flatcar-install random OEM FS UUID if duplicate

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="101e6c71ee2a07ef591eff3d9122a391713dbbf0" # flatcar-master
+	CROS_WORKON_COMMIT="36c9ebb5efff1f63f7d3e9380c738ece1af5c798" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/kinvolk/init/pull/47
to randomize OEM filesystem UUID if mounting fails, and to avoid trying
to install the QEMU qcow2 images.

