### PR TITLE
profiles: accept keyword ~arm64 for selinux

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -74,10 +74,11 @@ sys-apps/dtc ~arm64
 =sys-apps/i2c-tools-3.1.1-r1 ~arm64
 =sys-apps/lshw-02.17b-r2 **
 =sys-apps/man-db-2.7.6.1-r2 ~arm64
-sys-apps/policycoreutils *
+=sys-apps/policycoreutils-3.1-r2 ~arm64
 =sys-apps/pv-1.3.4 *
 =sys-apps/rng-tools-5-r2 **
 =sys-apps/sandbox-2.12 ~arm64
+=sys-apps/semodule-utils-3.1 ~arm64
 =sys-apps/smartmontools-6.4 **
 =sys-block/parted-3.2-r1 ~arm64
 =sys-block/thin-provisioning-tools-0.7.0 ~arm64
@@ -96,6 +97,9 @@ sys-apps/policycoreutils *
 =sys-libs/binutils-libs-2.29.1-r1 ~arm64
 =sys-libs/efivar-31 ~arm64
 =sys-libs/libcap-ng-0.7.8 ~arm64
+=sys-libs/libselinux-3.1-r1 ~arm64
+=sys-libs/libsemanage-3.1-r1 ~arm64
+=sys-libs/libsepol-3.1 ~arm64
 =sys-power/iasl-20161222 ~arm64
 =virtual/krb5-0-r1 ~arm64
 =virtual/libusb-1-r2 ~arm64


### PR DESCRIPTION
Now that `sys-apps/policycoreutils` is [pulled in](https://github.com/kinvolk/coreos-overlay/pull/1240) explicitly for both architectures, we should be able to pull in its dependencies, e.g.
`sys-apps/semodule-utils`, `sys-libs/libselinux`, `sys-libs/libsemanage`,
`sys-libs/libsepol`.
In case of arm64, however, all the ebuilds have only `~arm64`. So we need to enable the keywords for the ebuilds.

Without the changes, build fails like:

```
!!! All ebuilds that could satisfy
">=sys-libs/libselinux-3.1:=[python?,python_targets_python3_6(-)?,-python_single_target_python3_6(-)]"
for /build/arm64-usr/ have been masked.
!!! One of the following masked packages is required to complete your
request:
- sys-libs/libselinux-9999::coreos (masked by: missing keyword)
- sys-libs/libselinux-3.2::coreos (masked by: ~arm64 keyword)
- sys-libs/libselinux-3.1-r1::coreos (masked by: ~arm64 keyword)
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3468/cldsv