### PR TITLE
mdadm: migrate cron.weekly to systemd.timer

### DIFF
--- a/sys-fs/mdadm/files/mdadm.service
+++ b/sys-fs/mdadm/files/mdadm.service
@@ -2,4 +2,4 @@
 Description=Initiates a check run of an MD array's redundancy information.
 
 [Service]
-ExecStart=/usr/sbin/checkarray
+ExecStart=/usr/sbin/checkarray --cron --all --idle --quiet

--- a/sys-fs/mdadm/files/mdadm.service
+++ b/sys-fs/mdadm/files/mdadm.service
@@ -2,4 +2,5 @@
 Description=Initiates a check run of an MD array's redundancy information.
 
 [Service]
+Type=oneshot
 ExecStart=/usr/sbin/checkarray --cron --all --idle --quiet

--- a/sys-fs/mdadm/files/mdadm.service
+++ b/sys-fs/mdadm/files/mdadm.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Initiates a check run of an MD array's redundancy information.
+
+[Service]
+ExecStart=/usr/sbin/checkarray

--- a/sys-fs/mdadm/files/mdadm.timer
+++ b/sys-fs/mdadm/files/mdadm.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Weekly check for MD array's redundancy information.
+
+[Install]
+WantedBy=timers.target
+
+[Timer]
+OnCalendar=weekly
+Persistent=true

--- a/sys-fs/mdadm/files/mdadm.weekly
+++ b/sys-fs/mdadm/files/mdadm.weekly
@@ -1,5 +1,0 @@
-#!/bin/sh
-# This requires that AUTOCHECK is true in /etc/default/mdadm
-if [ -x /usr/sbin/checkarray ] && [ $(date +\%d) -le 7 ]; then
-	/usr/sbin/checkarray --cron --all --idle --quiet
-fi

--- a/sys-fs/mdadm/mdadm-4.1.ebuild
+++ b/sys-fs/mdadm/mdadm-4.1.ebuild
@@ -78,8 +78,7 @@ src_install() {
 	insinto /etc/default
 	newins "${FILESDIR}"/etc-default-mdadm mdadm
 
-	exeinto /etc/cron.weekly
-	newexe "${FILESDIR}"/mdadm.weekly mdadm
+	systemd_dounit "${FILESDIR}"/mdadm.service
 }
 
 pkg_postinst() {

--- a/sys-fs/mdadm/mdadm-4.1.ebuild
+++ b/sys-fs/mdadm/mdadm-4.1.ebuild
@@ -79,6 +79,7 @@ src_install() {
 	newins "${FILESDIR}"/etc-default-mdadm mdadm
 
 	systemd_dounit "${FILESDIR}"/mdadm.service
+	systemd_dounit "${FILESDIR}"/mdadm.timer
 }
 
 pkg_postinst() {

--- a/sys-fs/mdadm/mdadm-4.1.ebuild
+++ b/sys-fs/mdadm/mdadm-4.1.ebuild
@@ -80,6 +80,8 @@ src_install() {
 
 	systemd_dounit "${FILESDIR}"/mdadm.service
 	systemd_dounit "${FILESDIR}"/mdadm.timer
+
+	systemd_enable_service timers.target mdadm.timer
 }
 
 pkg_postinst() {


### PR DESCRIPTION
# Replace cron.weekly with systemd.timer

Add a mdadm.timer unit and associate it with the mdadm package and remove the cron.weekly.

## Testing done