### PR TITLE
profiles: Enable selinux for all targets

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -65,13 +65,11 @@ IUSE="selinux"
 
 RDEPEND=">=sys-apps/baselayout-3.0.0"
 
-# Optionally enable SELinux and pull in policy for containers
+# Optionally enable SELinux for dbus and systemd (but always install packages and pull in the SELinux policy for containers)
 RDEPEND="${RDEPEND}
 	sys-apps/dbus[selinux?]
 	sys-apps/systemd[selinux?]
-	selinux? (
-		sec-policy/selinux-virt
-	)"
+	"
 
 # Only applicable or available on amd64
 RDEPEND="${RDEPEND}
@@ -141,9 +139,14 @@ RDEPEND="${RDEPEND}
 	net-misc/wget
 	net-misc/whois
 	net-vpn/wireguard-tools
+	sec-policy/selinux-virt
+	sec-policy/selinux-base
+	sec-policy/selinux-base-policy
+	sec-policy/selinux-unconfined
 	sys-apps/acl
 	sys-apps/attr
 	sys-apps/coreutils
+	sys-apps/checkpolicy
 	sys-apps/dbus
 	sys-apps/diffutils
 	sys-apps/ethtool
@@ -163,6 +166,7 @@ RDEPEND="${RDEPEND}
 	sys-apps/rng-tools
 	sys-apps/sed
 	sys-apps/seismograph
+	sys-apps/semodule-utils
 	sys-apps/shadow
 	sys-apps/usbutils
 	sys-apps/util-linux

--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -1,17 +1,3 @@
-# Enable SELinux for amd64 targets
-coreos-base/coreos	    selinux
-sys-apps/dbus               selinux
-sys-apps/systemd            selinux
-
-# Enable SELinux for coreutils
-sys-apps/coreutils	    selinux
-
-# Enable SELinux for tar
-app-arch/tar                selinux
-
-# Enable SELinux for docker-runc
-app-emulation/docker-runc selinux
-
 # Only ship microcode currently distributed by Intel
 # See https://bugs.gentoo.org/654638#c11 by iucode-tool maintainer
 sys-firmware/intel-microcode vanilla

--- a/profiles/coreos/amd64/generic/use.mask
+++ b/profiles/coreos/amd64/generic/use.mask
@@ -1,2 +1,0 @@
-# Unmask selinux so it can be enabled selectively in package.use
--selinux

--- a/profiles/coreos/amd64/sdk/package.use
+++ b/profiles/coreos/amd64/sdk/package.use
@@ -1,5 +1,0 @@
-# Enable SELinux for amd64 targets
-app-arch/tar                selinux
-sys-apps/coreutils          selinux
-coreos-base/coreos          selinux
-

--- a/profiles/coreos/amd64/sdk/use.mask
+++ b/profiles/coreos/amd64/sdk/use.mask
@@ -1,2 +1,0 @@
-# Unmask selinux so it can be enabled selectively in package.use
--selinux

--- a/profiles/coreos/arm64/package.use
+++ b/profiles/coreos/arm64/package.use
@@ -6,6 +6,4 @@ net-dns/bind-tools -gssapi
 # FIXME: why isn't this set by default???
 sys-libs/ncurses unicode
 
-sys-apps/systemd -selinux
-
 sys-auth/polkit -introspection

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -70,6 +70,11 @@ dev-util/checkbashisms
 
 =sys-libs/libsepol-2.4 **
 =sys-libs/libselinux-2.4 **
+=sys-apps/checkpolicy-3.1 **
+=sec-policy/selinux-base-2.20200818-r2 **
+=sec-policy/selinux-base-policy-2.20200818-r2 **
+=sec-policy/selinux-unconfined-2.20200818-r2 **
+=sec-policy/selinux-virt-2.20200818-r2 **
 
 =net-misc/openssh-8.6_p1-r1 ~amd64 ~arm64
 

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -100,6 +100,20 @@ sys-apps/man-db -nls
 # Disable zstd to avoid adding it to prod images until something needs it
 sys-fs/btrfs-progs -zstd
 
+# Enable SELinux for all targets
+coreos-base/coreos          selinux
+sys-apps/dbus               selinux
+sys-apps/systemd            selinux
+
+# Enable SELinux for coreutils
+sys-apps/coreutils          selinux
+
+# Enable SELinux for tar
+app-arch/tar                selinux
+
+# Enable SELinux for docker-runc
+app-emulation/docker-runc selinux
+
 # enable regular expression processing in jq
 app-misc/jq oniguruma
 

--- a/profiles/coreos/base/use.mask
+++ b/profiles/coreos/base/use.mask
@@ -4,3 +4,6 @@ kdbus
 # We default to python 3.6 for now
 python_targets_python3_7
 python_single_target_python3_7
+
+# Unmask selinux so it can be enabled selectively in package.use
+-selinux


### PR DESCRIPTION
Move the USE options out of the amd64 path, specify selinux
packages as explicit dependency, and add accept keywords.

Replaces https://github.com/kinvolk/coreos-overlay/pull/135

## How to use

The goal is to enable the selinux tests again in kola.

## Testing done

Ongoing, have to check if selinux use flags get enabled and whether removing the kola exemption for selinux on arm64 works
http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3470/cldsv/